### PR TITLE
[core] add tasks to install `yay` as AUR helper

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -11,7 +11,10 @@ ENV SSH_PASSWORD som3th!ng
 RUN pacman -Syu --noconfirm \
   && pacman --noconfirm -S \
      sudo \
-     ansible
+     git \
+     ansible \
+  && mkdir -p /usr/share/ansible/plugins/modules \
+  && git clone https://github.com/kewlfft/ansible-aur.git /usr/share/ansible/plugins/modules
 COPY . /root/hanzo
 WORKDIR /root/hanzo
 

--- a/arch/orchestrate.yml
+++ b/arch/orchestrate.yml
@@ -24,15 +24,19 @@
   become: yes
   vars_files:
     - variables/versions.yml
-  roles:
-    - system
-    - shell
-    - development
-    - editors
-    - storages
-    - orchestrators
-    - provisioning
-    - cluster
-    - extras
-    - fonts
-    - { role: dotfiles, tags: ['dotfiles'] }
+  tasks:
+    - block:
+        - include_role: name=system
+        - include_role: name=aur
+        - include_role: name=shell
+        - include_role: name=development
+        - include_role: name=editors
+        - include_role: name=storages
+        - include_role: name=orchestrators
+        - include_role: name=provisioning
+        - include_role: name=cluster
+        - include_role: name=extras
+        - include_role: name=fonts
+        - include_role: name=dotfiles
+      always:
+        - include_role: name=cleanup

--- a/arch/roles/aur/tasks/main.yml
+++ b/arch/roles/aur/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+
+# Configures AUR repositories
+
+- name: Create aur_builder user
+  user:
+    name: aur_builder
+
+- name: Add aur_builder user to 'pacman' sudoers list
+  lineinfile:
+    path: /etc/sudoers.d/11-install-aur_builder
+    line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'
+    create: yes
+    validate: 'visudo -cf %s'
+
+- name: Install 'yay' AUR helper
+  aur:
+    name: yay
+    use: makepkg
+    skip_installed: true
+  become: yes
+  become_user: aur_builder

--- a/arch/roles/cleanup/tasks/main.yml
+++ b/arch/roles/cleanup/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+# Cleanup tasks that must be executed in any case (failure/success)
+
+- name: Remove aur_builder
+  user:
+    name: aur_builder
+    state: absent
+    remove: yes
+
+- name: Clean aur_builder permissions
+  file:
+    state: absent
+    path: /etc/sudoers.d/11-install-aur_builder


### PR DESCRIPTION
### Overview

Closes #122 

* Update `Dockerfile` to include `git` so that `ansible-aur` module can be installed before launching Ansible
* Change `roles` directive to `include_role` tasks
* Add `yay` task so that it can be used in the rest of the playbook; `aur_builder` temporary user is removed using `always` directive