### PR TITLE
[python] add pyenv and pipenv

### DIFF
--- a/arch/roles/development/tasks/python.yml
+++ b/arch/roles/development/tasks/python.yml
@@ -2,32 +2,27 @@
 
 # Python
 
-- name: Installing PIP
+- name: Installing Python
   pacman:
     state: latest
     name:
+      - python
       - python-pip
+      - python2
       - python2-pip
 
-- name: Checking Pythonz installation
-  register: pythonz
-  stat: path=/usr/local/pythonz
-
-- name: Downloading Pythonz installer
-  when: pythonz.stat.exists == False
-  get_url:
-    url: https://raw.github.com/saghul/pythonz/master/pythonz-install
-    dest: /tmp/pythonz-install.sh
-    mode: 0444
-
-- name: Installing Pythonz
-  when: pythonz.stat.exists == False
+- name: Installing 'pyenv'
+  aur:
+    name: pyenv
   become: yes
-  become_user: "{{username}}"
-  command: /bin/bash /tmp/pythonz-install.sh
+  become_user: aur_builder
 
 - name: Installing Python tools
   pip:
+    state: latest
+    extra_args: --user
     name:
       - ipython
-      - virtualenvwrapper
+      - pipenv
+  become: yes
+  become_user: "{{ username }}"


### PR DESCRIPTION
### Overview

Closes #104 

Replaces:
* `virtualenvwrapper` with `pipenv` 
* `pythonz` with `pyenv`