### PR TITLE
[docker] use official docker and docker-compose

### DIFF
--- a/arch/roles/orchestrators/tasks/docker.yml
+++ b/arch/roles/orchestrators/tasks/docker.yml
@@ -3,7 +3,11 @@
 # Docker
 
 - name: Installing docker containers
-  pacman: name=docker state=latest
+  pacman:
+    state: latest
+    name:
+      - docker
+      - docker-compose
 
 - name: Adding default user to docker group
   user: name={{username}} groups=docker append=yes


### PR DESCRIPTION
### Overview

Closes #115 

* syntax refactoring
* Add `docker-compose` from official repositories

### Caveat

This patch must be tested on a ChromeOS (Crostini) because a Docker patch was not available in the latest release. If that doesn't work, we should use `docker-git` (AUR) package to include the required patch.