### PR TITLE
[fonts] remove broken infinality repository

### DIFF
--- a/arch/roles/fonts/tasks/main.yml
+++ b/arch/roles/fonts/tasks/main.yml
@@ -11,14 +11,3 @@
       - adobe-source-code-pro-fonts
   notify:
     - build font cache
-
-- name: Installing infinality-bundle repository
-  blockinfile:
-    dest: /etc/pacman.conf
-    marker: "# {mark} FONTS MANAGED BLOCK (Ansible)"
-    block: |
-      [infinality-bundle]
-      Server = http://bohoomil.com/repo/$arch
-
-      [infinality-bundle-fonts]
-      Server = http://bohoomil.com/repo/fonts


### PR DESCRIPTION
### Overview

Infinality repository was broken, causing the following error:
```
warning: database file for 'infinality-bundle' does not exist (use '-Sy' to download)
warning: database file for 'infinality-bundle-fonts' does not exist (use '-Sy' to download)
warning: docker-1:18.09.3-1 is up to date -- reinstalling
error: failed to prepare transaction (could not find database)
```

That patch removes the repository, considering it's not needed anymore.