### PR TITLE
[ruby] add rbenv and ruby-build

### DIFF
--- a/arch/roles/development/tasks/ruby.yml
+++ b/arch/roles/development/tasks/ruby.yml
@@ -3,4 +3,14 @@
 # Ruby
 
 - name: Installing system Ruby
-  pacman: name=ruby state=latest
+  pacman:
+    state: latest
+    name: ruby
+
+- name: Installing 'rbenv'
+  aur:
+    name:
+      - rbenv
+      - ruby-build
+  become: yes
+  become_user: aur_builder


### PR DESCRIPTION
### Overview

Closes #106 

Add `rbenv` to install multiple versions of Ruby (development).