### PR TITLE
[ci] add CircleCI to build a Docker container orchestrated with Hanzo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2
+jobs:
+  build:
+    docker:
+        - image: docker:latest
+    steps:
+      - checkout
+
+      - setup_remote_docker:
+          docker_layer_caching: false
+
+      # Build the docker container that will be orchestrated with Hanzo.
+      # For more details check: https://github.com/palazzem/hanzo/blob/master/Dockerfile#L21-L23
+      - run: |
+          docker build -t hanzo:test .


### PR DESCRIPTION
### Overview

Closes #111 

Builds the Docker container defined in `Dockerfile`. It includes Hanzo orchestration, so if it succeed it means the Pull Request is good to go.