### PR TITLE
[chromeos] add ChromeOS installer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,48 +14,38 @@ my requirements and it's very unlikely it can be used in a general purpose sense
 
 .. _Ansible: https://www.ansible.com/
 
-ChromeOS requirements
----------------------
-
-If you're not using a ChromeOS device, you can skip this section. Otherwise you need to replace the default LXC
-container with a new one for ArchLinux.
-
-To replace the default LXC container, use the following steps:
-
-* Enable Linux support on ChromeOS
-* Open ``crosh`` using ``CTRL`` + ``ALT`` + ``T``
-* Bootstrap a new ArchLinux container as a default container::
-
-   $ vsh termina
-   $ lxc delete penguin --force
-   $ run_container.sh --container_name penguin --user <username> --lxd_image archlinux/current --lxd_remote https://us.images.linuxcontainers.org/
-   $ lxc exec penguin -- bash
-
-**NOTE**: ``<username>`` MUST be your Gmail account (without ``@gmail.com``) otherwise the integration will not work.
-
-Quick start guide
------------------
+Quickstart
+----------
 
 If you like living on the bleeding edge and *curlbombs* don't scare you, the automatic installer is the easiest
 way to configure your system::
 
     $ sh <(curl -L http://j.mp/hattori-hanzo)
 
-A clean ArchLinux installation is recommended but not required. Anyway, **bear in mind** that this configuration
-**WILL OVERWRITE ENTIRELY your system**.
+A clean ArchLinux installation is recommended but not required. Anyway, bear in mind it **WILL OVERWRITE ENTIRELY**
+your system.
 
 If you use this approach, nothing else is required and you can enjoy your new system!
 
-Alternative Installer
-~~~~~~~~~~~~~~~~~~~~~
+ChromeOS Installer
+~~~~~~~~~~~~~~~~~~
 
-You can split the above command using an MD5 hash check::
+If you're not using a ChromeOS device, you can skip this section.
+ChromeOS installer will replace the default LXC container with a new ArchLinux container configured with Hanzo. If
+you're using actively the default ChromeOS container, bear in mind it **WILL BE REMOVED** from your system
 
-    $ curl -L http://j.mp/hattori-hanzo -o hanzo.sh
-    $ echo 15af9d2f4d52c2eaec9ced10475b25a8  hanzo.sh | md5sum -c -
+To start the configuration, follow these steps:
 
-    # outputs:
-    # hanzo.sh: OK
+* Enable Linux support on your ChromeOS system
+* Open ``crosh`` using ``CTRL`` + ``ALT`` + ``T``
+* Access the ``termina`` VM and launch the ChromeOS installer::
+
+   $ vsh termina
+   $ sh <(curl -L http:/j.mp/hattori-hanzo-chromeos)
+
+* Hanzo is launched automatically and nothing else is required. Enjoy your new system!
+
+**NOTE**: Your Google account username MUST be your Gmail account (without ``@gmail.com``) otherwise the integration will not work.
 
 Manual installation
 -------------------
@@ -67,7 +57,7 @@ To use this playbook the following requirements must be installed::
    $ mkdir -p /usr/share/ansible/plugins/modules
 
    # Enables AUR Ansible module
-   $ git clone https://github.com/kewlfft/ansible-aur.git /usr/share/ansible/plugins/modules
+   $ git clone https://github.com/kewlfft/ansible-aur.git /usr/share/ansible/plugins/modules/aur
 
 Starting the orchestration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,8 @@ To start the configuration, follow these steps:
 * Access the ``termina`` VM and launch the ChromeOS installer::
 
    $ vsh termina
-   $ sh <(curl -L http:/j.mp/hattori-hanzo-chromeos)
+   $ curl -L http:/j.mp/hattori-hanzo-chromeos > /tmp/hanzo-installer.sh
+   $ bash /tmp/hanzo-installer.sh
 
 * Hanzo is launched automatically and nothing else is required. Enjoy your new system!
 

--- a/bin/chromeos-installer.sh
+++ b/bin/chromeos-installer.sh
@@ -29,18 +29,15 @@
 
 set -e
 
-# Variables
-BOOTSTRAP_SCRIPT=https://raw.githubusercontent.com/palazzem/hanzo/master/bin/bootstrap.sh
-
 # Prompt for mandatory parameters
 read -p "Provide your Google account username: " GOOGLE_USERNAME
 
 # Create a fresh ArchLinux LXC container
-lxc delete penguin --force
+lxc delete penguin --force || true
 run_container.sh --container_name penguin --user $GOOGLE_USERNAME --lxd_image archlinux/current --lxd_remote https://us.images.linuxcontainers.org/
 
 # Launch Hanzo bootstrap
-lxc exec penguin -- sh <(curl -L $BOOTSTRAP_SCRIPT)
+lxc exec penguin -- sh -c "curl -L https://raw.githubusercontent.com/palazzem/hanzo/master/bin/bootstrap.sh > /tmp/hanzo-installer.sh; bash /tmp/hanzo-installer.sh"
 
 # Stop the container so it's ready for use at the next start
 lxc stop penguin

--- a/bin/chromeos-installer.sh
+++ b/bin/chromeos-installer.sh
@@ -1,0 +1,46 @@
+#! /bin/bash
+
+# Copyright (c) 2014-2019, Emanuele Palazzetti and contributors
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+set -e
+
+# Variables
+BOOTSTRAP_SCRIPT=https://raw.githubusercontent.com/palazzem/hanzo/master/bin/bootstrap.sh
+
+# Prompt for mandatory parameters
+read -p "Provide your Google account username: " GOOGLE_USERNAME
+
+# Create a fresh ArchLinux LXC container
+lxc delete penguin --force
+run_container.sh --container_name penguin --user $GOOGLE_USERNAME --lxd_image archlinux/current --lxd_remote https://us.images.linuxcontainers.org/
+
+# Launch Hanzo bootstrap
+lxc exec penguin -- sh <(curl -L $BOOTSTRAP_SCRIPT)
+
+# Stop the container so it's ready for use at the next start
+lxc stop penguin

--- a/roles/chromeos/tasks/main.yml
+++ b/roles/chromeos/tasks/main.yml
@@ -34,6 +34,18 @@
   file: state=link src={{item.src}} dest={{item.dest}}
   with_items:
       - { src: "/home/{{username}}/.dotfiles/config/mime.types", dest: "/etc/mime.types" }
+
+# ChromeOS binaries are available only when the LXC container is mounted in the
+# `termina` VM (in ChromeOS). This test is required otherwise our CI fails because
+# the binaries are not available.
+- name: Checking ChromeOS mounted binaries
+  register: cros
+  stat: path=/opt/google/cros-containers/bin/
+
+- name: Symlink ChromeOS binaries
+  file: state=link src={{item.src}} dest={{item.dest}}
+  when: cros.stat.exists == True
+  with_items:
       - { src: "/opt/google/cros-containers/bin/sommelier", dest: "/usr/bin/sommelier" }
 
 # Sommelier is enabled via symlink because `systemctl` cannot be used

--- a/roles/development/templates/gitconfig.j2
+++ b/roles/development/templates/gitconfig.j2
@@ -4,7 +4,7 @@
 
 [alias]
     co = checkout
-    ci = commit
+    ci = commit -S
     st = status
     br = branch
     lg = log --graph --abbrev-commit --decorate --date=relative --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(bold yellow)%d%C(reset)' --all

--- a/roles/fonts/tasks/main.yml
+++ b/roles/fonts/tasks/main.yml
@@ -18,5 +18,3 @@
   aur:
     name:
       - ttf-symbola
-  notify:
-    - build font cache

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -6,7 +6,7 @@
   pacman:
     state: latest
     name:
-      - termite
+      - sakura
       - zsh
 
 - name: Checking Oh-my-ZSH presence


### PR DESCRIPTION
### Overview

Closes #142 

Instead of relying in documentation, this installer replaces the default Debian LXC container with a new ArchLinux container configured with Hanzo.