### PR TITLE
[fonts] artwiz-fonts is available only on AUR

### DIFF
--- a/roles/fonts/tasks/main.yml
+++ b/roles/fonts/tasks/main.yml
@@ -7,7 +7,6 @@
     state: latest
     name:
       - ttf-dejavu
-      - artwiz-fonts
       - adobe-source-code-pro-fonts
   notify:
     - build font cache
@@ -18,3 +17,4 @@
   aur:
     name:
       - ttf-symbola
+      - artwiz-fonts


### PR DESCRIPTION
### Overview

`artwiz-fonts` is now installed as AUR package because it's not available in ArchLinux repository.