### PR TITLE
[system] add openssl and openssl-1.0 packages

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -31,6 +31,8 @@
       - ntfsprogs
       - ntp
       - openssh
+      - openssl
+      - openssl-1.0
       - p7zip
       - sudo
       - tar


### PR DESCRIPTION
### Overview

Closes #155  

OpenSSL-1.0 is needed to build Python 3.4.