### PR TITLE
[python] replace pipenv with virtualenvwrapper and pip-tools

### DIFF
--- a/roles/development/tasks/python.yml
+++ b/roles/development/tasks/python.yml
@@ -23,6 +23,7 @@
     extra_args: --user
     name:
       - ipython
-      - pipenv
+      - pip-tools
+      - virtualenvwrapper
   become: yes
   become_user: "{{ username }}"


### PR DESCRIPTION
### Overview

Closes #154 

* Remove `pipenv`
* Add `virtualenvwrapper` and `pip-tools` packages