### PR TITLE
[dotfiles] add symbolic link for zshenv file

### DIFF
--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -10,6 +10,7 @@
   file: state=absent name={{item}}
   with_items:
     - "/home/{{username}}/.zshrc"
+    - "/home/{{username}}/.zshenv"
     - "/home/{{username}}/.spacemacs"
     - "/home/{{username}}/.config/sakura/sakura.conf"
 
@@ -22,5 +23,6 @@
   file: state=link src={{item.src}} dest={{item.dest}} owner={{username}} group={{username}}
   with_items:
       - { src: "/home/{{username}}/.dotfiles/zshrc", dest: "/home/{{username}}/.zshrc" }
+      - { src: "/home/{{username}}/.dotfiles/zshenv", dest: "/home/{{username}}/.zshenv" }
       - { src: "/home/{{username}}/.dotfiles/spacemacs", dest: "/home/{{username}}/.spacemacs" }
       - { src: "/home/{{username}}/.dotfiles/config/sakura/sakura.conf", dest: "/home/{{username}}/.config/sakura/sakura.conf" }


### PR DESCRIPTION
### Overview

In `dotfiles` the `.zshrc` has been split into `.zshrc` and `.zshenv`. This PR adds a symbolic link for `.zshenv`.