### PR TITLE
Improve ChromeOS installer

### DIFF
--- a/bin/chromeos-installer.sh
+++ b/bin/chromeos-installer.sh
@@ -29,12 +29,9 @@
 
 set -e
 
-# Prompt for mandatory parameters
-read -p "Provide your Google account username: " GOOGLE_USERNAME
-
 # Create a fresh ArchLinux LXC container
 lxc delete penguin --force || true
-run_container.sh --container_name penguin --user $GOOGLE_USERNAME --lxd_image archlinux/current --lxd_remote https://us.images.linuxcontainers.org/
+run_container.sh --container_name penguin --lxd_image archlinux/current --lxd_remote https://us.images.linuxcontainers.org/
 
 # Launch Hanzo bootstrap
 lxc exec penguin -- sh -c "curl -L https://raw.githubusercontent.com/palazzem/hanzo/master/bin/bootstrap.sh > /tmp/hanzo-installer.sh; bash /tmp/hanzo-installer.sh"

--- a/bin/chromeos-installer.sh
+++ b/bin/chromeos-installer.sh
@@ -32,8 +32,15 @@ set -e
 # Create a fresh ArchLinux LXC container
 lxc delete penguin --force || true
 run_container.sh --container_name penguin --lxd_image archlinux/current --lxd_remote https://us.images.linuxcontainers.org/
+echo "Waiting the container to be up and running... (5s)"; sleep 5s
+
+# Address DNS resolution error: https://wiki.archlinux.org/index.php/Chrome_OS_devices/Crostini#DNS_resolution_not_working
+lxc exec penguin -- sh -c "sed -i 's/hosts.*/hosts: files dns/g' /etc/nsswitch.conf"
+lxc exec penguin -- sh -c "ping -c 4 google.com"
+echo "LXC container connected to the Internet!"
 
 # Launch Hanzo bootstrap
+echo "Downloading Hanzo..."
 lxc exec penguin -- sh -c "curl -L https://raw.githubusercontent.com/palazzem/hanzo/master/bin/bootstrap.sh > /tmp/hanzo-installer.sh; bash /tmp/hanzo-installer.sh"
 
 # Stop the container so it's ready for use at the next start


### PR DESCRIPTION
### Overview

Closes #153 
Closes #166

ChromeOS installer is improved so that:
* Username is asked only once
* When ArchLinux runs in a LXC container, [DNS resolution is not working](https://wiki.archlinux.org/index.php/Chrome_OS_devices/Crostini#DNS_resolution_not_working) making `hanzo` not downloadable. With this change Internet connection is restored before attempting to install `hanzo`.