### PR TITLE
[shell] update Sakura launcher to use Sommelier

### DIFF
--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -18,3 +18,11 @@
   become: yes
   become_user: "{{username}}"
   git: repo=https://github.com/robbyrussell/oh-my-zsh.git dest="/home/{{username}}/.oh-my-zsh"
+
+- name: Updating Sakura launcher to use Sommelier
+  replace:
+    dest: /usr/share/applications/sakura.desktop
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { regexp: 'Exec=sakura', replace: 'Exec=sommelier -X sakura' }


### PR DESCRIPTION
### Overview

Closes #151

Sakura is the only really impacted by the problem. This PR updates the launcher so that `sommelier` is used to provide the right integration.