### PR TITLE
[tasks/chromeos] Remove mime.types configuration

### DIFF
--- a/roles/chromeos/tasks/main.yml
+++ b/roles/chromeos/tasks/main.yml
@@ -25,16 +25,6 @@
     - { regexp: '<I372>.*', replace: '// <I372> = 372;' }
     - { regexp: '<I374>.*', replace: '// <I374> = 374;' }
 
-- name: Configure the container (config files)
-  file: state=touch path={{item.path}} owner={{username}} group={{username}}
-  with_items:
-      - { path: "/home/{{username}}/.mime.types" }
-
-- name: Configure the container (symlinks)
-  file: state=link src={{item.src}} dest={{item.dest}}
-  with_items:
-      - { src: "/home/{{username}}/.dotfiles/config/mime.types", dest: "/etc/mime.types" }
-
 # ChromeOS binaries are available only when the LXC container is mounted in the
 # `termina` VM (in ChromeOS). This test is required otherwise our CI fails because
 # the binaries are not available.


### PR DESCRIPTION
### Overview

Follow-up after the CI failure noticed on #171.

To support ArchLinux as an LXC container in ChromeOS, [this change]((https://github.com/palazzem/hanzo/commit/0543e1234e859c115e726be0bf40f83aa1f69dec#diff-fba63fbc93b71b6ed72e15db0c474de9R28-R37)) was introduced to prevent `garcon` from crashing. Recently, the `mime.types` file is available in the ArchLinux base image, so this change is not required anymore.