### PR TITLE
Split ChromeOS installer from Archlinux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,21 @@
-version: 2
+version: 2.1
 jobs:
-  build:
+  # Build the docker container that will be orchestrated with Hanzo.
+  # For more details check: https://github.com/palazzem/hanzo/blob/master/Dockerfile#L21-L23
+  archlinux-installer:
     machine: true
     steps:
       - checkout
-      # Build the docker container that will be orchestrated with Hanzo.
-      # For more details check: https://github.com/palazzem/hanzo/blob/master/Dockerfile#L21-L23
       - run: docker build -t hanzo:test .
+  chromeos-installer:
+    machine: true
+    steps:
+      - checkout
+      - run: docker build -t hanzo:test --build-arg TAGS=chromeos .
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - archlinux-installer
+      - chromeos-installer

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM archlinux/base
 LABEL maintainer="hello@palazzetti.me"
 
 # Configure testing environment
+ARG TAGS
 ENV HANZO_FULLNAME test
 ENV HANZO_USERNAME test
 ENV HANZO_EMAIL test@example.com
@@ -20,4 +21,4 @@ WORKDIR /root/hanzo
 
 # Provisioning during the build so that a container correctly
 # built corresponds to a successful test
-RUN ansible-playbook orchestrate.yml --connection=local --verbose
+RUN ansible-playbook orchestrate.yml --connection=local --verbose --tags=$TAGS

--- a/orchestrate.yml
+++ b/orchestrate.yml
@@ -37,5 +37,6 @@
         - include_role: name=extras
         - include_role: name=dotfiles
         - include_role: name=chromeos
+          tags: ['never', 'chromeos']
       always:
         - include_role: name=cleanup

--- a/orchestrate.yml
+++ b/orchestrate.yml
@@ -31,7 +31,6 @@
         - include_role: name=security
         - include_role: name=development
         - include_role: name=editors
-        - include_role: name=storages
         - include_role: name=orchestrators
         - include_role: name=provisioning
         - include_role: name=cluster

--- a/orchestrate.yml
+++ b/orchestrate.yml
@@ -3,6 +3,8 @@
 # Overview: configuring a developer machine in just minutes
 
 - hosts: localhost
+  name: Hanzo Lookup
+  tags: always
   tasks:
     - name: Configure the environment
       set_fact:
@@ -21,6 +23,8 @@
         - username
 
 - hosts: localhost
+  name: Archlinux/toolbox
+  tags: always
   become: yes
   tasks:
     - block:
@@ -36,7 +40,16 @@
         - include_role: name=cluster
         - include_role: name=extras
         - include_role: name=dotfiles
+      always:
+        - include_role: name=cleanup
+
+- hosts: localhost
+  name: ChromeOS Installer
+  tags: [ never, chromeos ]
+  become: yes
+  tasks:
+    - block:
+        - include_role: name=aur
         - include_role: name=chromeos
-          tags: ['never', 'chromeos']
       always:
         - include_role: name=cleanup

--- a/roles/chromeos/tasks/dotfiles.yml
+++ b/roles/chromeos/tasks/dotfiles.yml
@@ -1,0 +1,18 @@
+---
+
+# Updating dotfiles
+
+- name: Removing old files (if any)
+  file: state=absent name={{item}}
+  with_items:
+    - "/home/{{username}}/.config/sakura/sakura.conf"
+
+- name: Creating folders for dotfiles
+  file: state=directory name={{item}} owner={{username}} group={{username}}
+  with_items:
+    - "/home/{{username}}/.config/sakura"
+
+- name: Creating symbolic links
+  file: state=link src={{item.src}} dest={{item.dest}} owner={{username}} group={{username}}
+  with_items:
+      - { src: "/home/{{username}}/.dotfiles/config/sakura/sakura.conf", dest: "/home/{{username}}/.config/sakura/sakura.conf" }

--- a/roles/chromeos/tasks/main.yml
+++ b/roles/chromeos/tasks/main.yml
@@ -1,57 +1,7 @@
 ---
 
-# ChromeOS dependencies so that UI applications can be used
-
-- name: Installing Wayland
-  pacman:
-    state: latest
-    name:
-      - wayland
-      - packagekit
-      - xorg-server-xwayland
-
-- name: Installing Containers Guest Tools
-  aur:
-    name: cros-container-guest-tools-git
-  become: yes
-  become_user: aur_builder
-
-- name: Fixing xkeyboard-config 2.24 break the sommelier-x service
-  replace:
-    dest: /usr/share/X11/xkb/keycodes/evdev
-    regexp: "{{ item.regexp }}"
-    replace: "{{ item.replace }}"
-  with_items:
-    - { regexp: '<I372>.*', replace: '// <I372> = 372;' }
-    - { regexp: '<I374>.*', replace: '// <I374> = 374;' }
-
-# ChromeOS binaries are available only when the LXC container is mounted in the
-# `termina` VM (in ChromeOS). This test is required otherwise our CI fails because
-# the binaries are not available.
-- name: Checking ChromeOS mounted binaries
-  register: cros
-  stat: path=/opt/google/cros-containers/bin/
-
-- name: Symlink ChromeOS binaries
-  file: state=link src={{item.src}} dest={{item.dest}}
-  when: cros.stat.exists == True
-  with_items:
-      - { src: "/opt/google/cros-containers/bin/sommelier", dest: "/usr/bin/sommelier" }
-
-# Sommelier is enabled via symlink because `systemctl` cannot be used
-# when commands are executed directly on the LXC container, without
-# a proper login. To make it work via `systemctl` it's required to
-# access via `lxc console`.
-- name: Creating 'default.target.wants' folder for systemd
-  file: path="/home/{{username}}/.config/systemd/user/default.target.wants" owner={{username}} group={{username}} state=directory
-
-- name: Enabling Sommelier via systemctl
-  become: true
-  become_user: "{{ username }}"
-  file:
-    state: link
-    src: '{{ item.src }}'
-    dest: '{{ item.dest }}'
-  with_items:
-    - { src: '/usr/lib/systemd/user/sommelier@.service', dest: '/home/{{username}}/.config/systemd/user/default.target.wants/sommelier@0.service'}
-    - { src: '/usr/lib/systemd/user/sommelier-x@.service', dest: '/home/{{username}}/.config/systemd/user/default.target.wants/sommelier-x@0.service'}
+# ChromeOS specific tasks to configure the LXC container integration
+# with the rest of the system
+- include: shell.yml
+- include: dotfiles.yml
+- include: wayland.yml

--- a/roles/chromeos/tasks/shell.yml
+++ b/roles/chromeos/tasks/shell.yml
@@ -1,0 +1,17 @@
+---
+
+# Shell Configuration
+
+- name: Installing the Terminal
+  pacman:
+    state: latest
+    name:
+      - sakura
+
+- name: Updating Sakura launcher to use Sommelier
+  replace:
+    dest: /usr/share/applications/sakura.desktop
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { regexp: 'Exec=sakura', replace: 'Exec=sommelier -X sakura' }

--- a/roles/chromeos/tasks/wayland.yml
+++ b/roles/chromeos/tasks/wayland.yml
@@ -1,0 +1,57 @@
+---
+
+# ChromeOS dependencies so that UI applications can be used
+
+- name: Installing Wayland
+  pacman:
+    state: latest
+    name:
+      - wayland
+      - packagekit
+      - xorg-server-xwayland
+
+- name: Installing Containers Guest Tools
+  aur:
+    name: cros-container-guest-tools-git
+  become: yes
+  become_user: aur_builder
+
+- name: Fixing xkeyboard-config 2.24 break the sommelier-x service
+  replace:
+    dest: /usr/share/X11/xkb/keycodes/evdev
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { regexp: '<I372>.*', replace: '// <I372> = 372;' }
+    - { regexp: '<I374>.*', replace: '// <I374> = 374;' }
+
+# ChromeOS binaries are available only when the LXC container is mounted in the
+# `termina` VM (in ChromeOS). This test is required otherwise our CI fails because
+# the binaries are not available.
+- name: Checking ChromeOS mounted binaries
+  register: cros
+  stat: path=/opt/google/cros-containers/bin/
+
+- name: Symlink ChromeOS binaries
+  file: state=link src={{item.src}} dest={{item.dest}}
+  when: cros.stat.exists == True
+  with_items:
+      - { src: "/opt/google/cros-containers/bin/sommelier", dest: "/usr/bin/sommelier" }
+
+# Sommelier is enabled via symlink because `systemctl` cannot be used
+# when commands are executed directly on the LXC container, without
+# a proper login. To make it work via `systemctl` it's required to
+# access via `lxc console`.
+- name: Creating 'default.target.wants' folder for systemd
+  file: path="/home/{{username}}/.config/systemd/user/default.target.wants" owner={{username}} group={{username}} state=directory
+
+- name: Enabling Sommelier via systemctl
+  become: true
+  become_user: "{{ username }}"
+  file:
+    state: link
+    src: '{{ item.src }}'
+    dest: '{{ item.dest }}'
+  with_items:
+    - { src: '/usr/lib/systemd/user/sommelier@.service', dest: '/home/{{username}}/.config/systemd/user/default.target.wants/sommelier@0.service'}
+    - { src: '/usr/lib/systemd/user/sommelier-x@.service', dest: '/home/{{username}}/.config/systemd/user/default.target.wants/sommelier-x@0.service'}

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -10,6 +10,7 @@
       - gdb
       - git
       - mercurial
+      - sqlite
 
 - name: Configuring .gitconfig
   template: src=gitconfig.j2 dest="/home/{{username}}/.gitconfig" owner={{username}} group={{username}} mode=0644

--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -14,7 +14,8 @@
     - "/home/{{username}}/.spacemacs"
     - "/home/{{username}}/.config/sakura/sakura.conf"
 
-- name: Creating folders for dotfiles
+- name: "[ChromeOS] Creating folders for dotfiles"
+  tags: ['never', 'chromeos']
   file: state=directory name={{item}} owner={{username}} group={{username}}
   with_items:
     - "/home/{{username}}/.config/sakura"
@@ -25,4 +26,9 @@
       - { src: "/home/{{username}}/.dotfiles/zshrc", dest: "/home/{{username}}/.zshrc" }
       - { src: "/home/{{username}}/.dotfiles/zshenv", dest: "/home/{{username}}/.zshenv" }
       - { src: "/home/{{username}}/.dotfiles/spacemacs", dest: "/home/{{username}}/.spacemacs" }
+
+- name: "[ChromeOS] Creating symbolic links"
+  tags: ['never', 'chromeos']
+  file: state=link src={{item.src}} dest={{item.dest}} owner={{username}} group={{username}}
+  with_items:
       - { src: "/home/{{username}}/.dotfiles/config/sakura/sakura.conf", dest: "/home/{{username}}/.config/sakura/sakura.conf" }

--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -12,13 +12,6 @@
     - "/home/{{username}}/.zshrc"
     - "/home/{{username}}/.zshenv"
     - "/home/{{username}}/.spacemacs"
-    - "/home/{{username}}/.config/sakura/sakura.conf"
-
-- name: "[ChromeOS] Creating folders for dotfiles"
-  tags: ['never', 'chromeos']
-  file: state=directory name={{item}} owner={{username}} group={{username}}
-  with_items:
-    - "/home/{{username}}/.config/sakura"
 
 - name: Creating symbolic links
   file: state=link src={{item.src}} dest={{item.dest}} owner={{username}} group={{username}}
@@ -26,9 +19,3 @@
       - { src: "/home/{{username}}/.dotfiles/zshrc", dest: "/home/{{username}}/.zshrc" }
       - { src: "/home/{{username}}/.dotfiles/zshenv", dest: "/home/{{username}}/.zshenv" }
       - { src: "/home/{{username}}/.dotfiles/spacemacs", dest: "/home/{{username}}/.spacemacs" }
-
-- name: "[ChromeOS] Creating symbolic links"
-  tags: ['never', 'chromeos']
-  file: state=link src={{item.src}} dest={{item.dest}} owner={{username}} group={{username}}
-  with_items:
-      - { src: "/home/{{username}}/.dotfiles/config/sakura/sakura.conf", dest: "/home/{{username}}/.config/sakura/sakura.conf" }

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -1,13 +1,19 @@
 ---
 
-# Install ZSH
+# Install Shell tools
 
 - name: Installing Shell packages
   pacman:
     state: latest
     name:
-      - sakura
       - zsh
+
+- name: "[ChromeOS] Installing the Terminal"
+  tags: ['never', 'chromeos']
+  pacman:
+    state: latest
+    name:
+      - sakura
 
 - name: Checking Oh-my-ZSH presence
   register: zsh
@@ -19,7 +25,8 @@
   become_user: "{{username}}"
   git: repo=https://github.com/robbyrussell/oh-my-zsh.git dest="/home/{{username}}/.oh-my-zsh"
 
-- name: Updating Sakura launcher to use Sommelier
+- name: "[ChromeOS] Updating Sakura launcher to use Sommelier"
+  tags: ['never', 'chromeos']
   replace:
     dest: /usr/share/applications/sakura.desktop
     regexp: "{{ item.regexp }}"

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -8,13 +8,6 @@
     name:
       - zsh
 
-- name: "[ChromeOS] Installing the Terminal"
-  tags: ['never', 'chromeos']
-  pacman:
-    state: latest
-    name:
-      - sakura
-
 - name: Checking Oh-my-ZSH presence
   register: zsh
   stat: path="/home/{{username}}/.oh-my-zsh"
@@ -24,12 +17,3 @@
   become: yes
   become_user: "{{username}}"
   git: repo=https://github.com/robbyrussell/oh-my-zsh.git dest="/home/{{username}}/.oh-my-zsh"
-
-- name: "[ChromeOS] Updating Sakura launcher to use Sommelier"
-  tags: ['never', 'chromeos']
-  replace:
-    dest: /usr/share/applications/sakura.desktop
-    regexp: "{{ item.regexp }}"
-    replace: "{{ item.replace }}"
-  with_items:
-    - { regexp: 'Exec=sakura', replace: 'Exec=sommelier -X sakura' }

--- a/roles/storages/tasks/main.yml
+++ b/roles/storages/tasks/main.yml
@@ -1,6 +1,0 @@
----
-
-# Supported storages tools
-
-- name: Installing SQLite
-  pacman: name=sqlite state=latest


### PR DESCRIPTION
### Overview

Closes #170 

ChromeOS is moved in a separated playbook, so that it's possible to leverage tags to executed ChromeOS installer. The base Archlinux installer is always executed if no tags are set. The following is a list of tags associated to each Ansible playbook:
```bash
playbook: orchestrate.yml

  play #1 (localhost): Hanzo Lookup	TAGS: [always]
    tasks:
      Configure the environment	TAGS: [always]
      Checking required variables	TAGS: [always]

  play #2 (localhost): Archlinux/toolbox	TAGS: [always]
    tasks:
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]
      include_role	TAGS: [always]

  play #3 (localhost): ChromeOS Installer	TAGS: [chromeos,never]
    tasks:
      include_role	TAGS: [chromeos, never]
      include_role	TAGS: [chromeos, never]
```