### PR TITLE
Remove SSH key generation

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -40,8 +40,6 @@ ROOT_FOLDER=/root/.hanzo/
 read -p "Provide your full name: " HANZO_FULLNAME; export HANZO_FULLNAME
 read -p "Provide your username: " HANZO_USERNAME; export HANZO_USERNAME
 read -p "Provide your email: " HANZO_EMAIL; export HANZO_EMAIL
-echo -n "Provide your SSH password (encrypt private key): "
-read -s HANZO_SSH_PASSWORD; export HANZO_SSH_PASSWORD
 
 # System update and dependencies
 echo "Updating the system..."; pacman -Syyu --noconfirm

--- a/orchestrate.yml
+++ b/orchestrate.yml
@@ -11,7 +11,6 @@
         email: "{{ lookup('env', 'HANZO_EMAIL') | default(false, True) }}"
         fullname: "{{ lookup('env', 'HANZO_FULLNAME') | default(false, True) }}"
         username: "{{ lookup('env', 'HANZO_USERNAME') | default(false, True) }}"
-        ssh_password: "{{ lookup('env', 'HANZO_SSH_PASSWORD') | default(false, True) }}"
     - name: Checking required variables
       fail:
         msg: "Variable '{{item}}' is not defined."
@@ -19,7 +18,6 @@
       with_items:
         - email
         - fullname
-        - ssh_password
         - username
 
 - hosts: localhost

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -44,9 +44,6 @@
 - name: Adding default user
   user: name={{username}} groups=wheel append=yes
 
-- name: Creating a default SSH key
-  user: name={{username}} generate_ssh_key=yes ssh_key_bits=8192 ssh_key_passphrase={{ssh_password}}
-
 - name: Creating 'programs' folder
   file: path="/home/{{username}}/programs" owner={{username}} group={{username}} state=directory
 


### PR DESCRIPTION
### Overview

The `system` task generates an SSH key with `8192` bits size. This step is critical and even if Ansible is reliable and secure, it's possible that in the future we add third-party modules that may invalidate the chain of trust. Because of that, it's better to keep this step offline and outside this playbook.