### PR TITLE
Use Ansible Portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,22 +3,25 @@ LABEL maintainer="hello@palazzetti.me"
 
 # Configure testing environment
 ARG TAGS
+ENV ANSIBLE_VERSION=2.9.2
 ENV HANZO_FULLNAME test
 ENV HANZO_USERNAME test
 ENV HANZO_EMAIL test@example.com
 ENV HANZO_SSH_PASSWORD som3th!ng
 
-# Install Hanzo with requirements
-RUN pacman -Syu --noconfirm \
-  && pacman --noconfirm -S \
-     sudo \
-     git \
-     ansible \
-  && mkdir -p /usr/share/ansible/plugins/modules \
-  && git clone https://github.com/kewlfft/ansible-aur.git /usr/share/ansible/plugins/modules
 COPY . /root/hanzo
 WORKDIR /root/hanzo
 
+# Install Ansible Portable
+RUN pacman -Sy tar python --noconfirm && \
+  curl -L https://github.com/palazzem/ansible-portable/releases/download/$ANSIBLE_VERSION/ansible-$ANSIBLE_VERSION.tar.gz > /tmp/ansible.tar.gz && \
+  curl -L https://github.com/kewlfft/ansible-aur/archive/v0.24.tar.gz > /tmp/aur.tar.gz && \
+  tar -xf /tmp/ansible.tar.gz && \
+  tar -xf /tmp/aur.tar.gz -C /tmp && \
+  mkdir library && \
+  mv /tmp/ansible-aur-0.24/aur.py ./library && \
+  ln -s ansible ansible-$ANSIBLE_VERSION/ansible-playbook
+
 # Provisioning during the build so that a container correctly
 # built corresponds to a successful test
-RUN ansible-playbook orchestrate.yml --connection=local --verbose --tags=$TAGS
+RUN PYTHONPATH=ansible-$ANSIBLE_VERSION python ansible-$ANSIBLE_VERSION/ansible-playbook orchestrate.yml --connection=local --verbose --tags=$TAGS

--- a/bin/chromeos-installer.sh
+++ b/bin/chromeos-installer.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Copyright (c) 2014-2019, Emanuele Palazzetti and contributors
+# Copyright (c) 2014-2020, Emanuele Palazzetti and contributors
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -40,8 +40,8 @@ lxc exec penguin -- sh -c "ping -c 4 google.com"
 echo "LXC container connected to the Internet!"
 
 # Launch Hanzo bootstrap
-echo "Downloading Hanzo..."
-lxc exec penguin -- sh -c "curl -L https://raw.githubusercontent.com/palazzem/hanzo/master/bin/bootstrap.sh > /tmp/hanzo-installer.sh; bash /tmp/hanzo-installer.sh"
+echo "Downloading Hanzo bootstrap..."
+lxc exec penguin -- sh -c "curl -L https://raw.githubusercontent.com/palazzem/hanzo/master/bin/bootstrap.sh > /tmp/hanzo-installer.sh; TAGS=chromeos bash /tmp/hanzo-installer.sh"
 
 # Stop the container so it's ready for use at the next start
 lxc stop penguin


### PR DESCRIPTION
### Overview

Closes #173 

Hanzo was using Ansible as a strict dependency in the `bootstrap.sh` script. The side effect of that, is that all Python dependencies (i.e. `pyyaml`) were installed at the system level using Archlinux packages. This makes the system not clean and it's better to keep Hanzo dependencies isolated.

This PR introduces [Ansible Portable](https://github.com/palazzem/ansible-portable) that is a standalone package with all the dependencies installed.