### PR TITLE
Hanzo test suite checks the bootstrap script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,30 @@
 version: 2.1
 jobs:
-  # Build the docker container that will be orchestrated with Hanzo.
-  # For more details check: https://github.com/palazzem/hanzo/blob/master/Dockerfile#L21-L23
   archlinux-installer:
-    machine: true
+    docker:
+      - image: archlinux/base
+        environment:
+          EXTRA_ARGS: --verbose
+          HANZO_FULLNAME: test
+          HANZO_USERNAME: test
+          HANZO_EMAIL: test@example.com
+          HANZO_FOLDER: /root/project/
     steps:
       - checkout
-      - run: docker build -t hanzo:test .
+      - run: bash bin/bootstrap.sh
   chromeos-installer:
-    machine: true
+    docker:
+      - image: archlinux/base
+        environment:
+          TAGS: chromeos
+          EXTRA_ARGS: --verbose
+          HANZO_FULLNAME: test
+          HANZO_USERNAME: test
+          HANZO_EMAIL: test@example.com
+          HANZO_FOLDER: /root/project/
     steps:
       - checkout
-      - run: docker build -t hanzo:test --build-arg TAGS=chromeos .
+      - run: bash bin/bootstrap.sh
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="hello@palazzetti.me"
 
 # Configure testing environment
 ARG TAGS
+ENV EXTRA_ARGS --verbose
 ENV HANZO_FULLNAME test
 ENV HANZO_USERNAME test
 ENV HANZO_EMAIL test@example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,14 @@ LABEL maintainer="hello@palazzetti.me"
 
 # Configure testing environment
 ARG TAGS
-ENV ANSIBLE_VERSION=2.9.2
 ENV HANZO_FULLNAME test
 ENV HANZO_USERNAME test
 ENV HANZO_EMAIL test@example.com
-ENV HANZO_SSH_PASSWORD som3th!ng
+ENV HANZO_FOLDER /root/hanzo
 
 COPY . /root/hanzo
 WORKDIR /root/hanzo
 
-# Install Ansible Portable
-RUN pacman -Sy tar python --noconfirm && \
-  curl -L https://github.com/palazzem/ansible-portable/releases/download/$ANSIBLE_VERSION/ansible-$ANSIBLE_VERSION.tar.gz > /tmp/ansible.tar.gz && \
-  curl -L https://github.com/kewlfft/ansible-aur/archive/v0.24.tar.gz > /tmp/aur.tar.gz && \
-  tar -xf /tmp/ansible.tar.gz && \
-  tar -xf /tmp/aur.tar.gz -C /tmp && \
-  mkdir library && \
-  mv /tmp/ansible-aur-0.24/aur.py ./library && \
-  ln -s ansible ansible-$ANSIBLE_VERSION/ansible-playbook
-
-# Provisioning during the build so that a container correctly
-# built corresponds to a successful test
-RUN PYTHONPATH=ansible-$ANSIBLE_VERSION python ansible-$ANSIBLE_VERSION/ansible-playbook orchestrate.yml --connection=local --verbose --tags=$TAGS
+# Provisioning at build time so that if a container builds correctly,
+# the test is successful
+RUN bash bin/bootstrap.sh

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -31,6 +31,7 @@ set -e
 
 # Variables
 ANSIBLE_VERSION=2.9.2
+ANSIBLE_FOLDER="ansible-$ANSIBLE_VERSION"
 REPOSITORY=https://github.com/palazzem/hanzo.git
 OUT_FOLDER=/root/.hanzo/
 
@@ -58,7 +59,7 @@ fi
 cd "$OUT_FOLDER"
 
 # Install Ansible Portable if not available
-if [ ! -d "$OUT_FOLDER/ansible-$ANSIBLE_VERSION" ]; then
+if [ ! -d "$OUT_FOLDER/$ANSIBLE_FOLDER" ]; then
     echo "Installing Ansible Portable..."
     pacman -Sy tar python --noconfirm
     curl -L https://github.com/palazzem/ansible-portable/releases/download/$ANSIBLE_VERSION/ansible-$ANSIBLE_VERSION.tar.gz > /tmp/ansible.tar.gz
@@ -67,19 +68,15 @@ if [ ! -d "$OUT_FOLDER/ansible-$ANSIBLE_VERSION" ]; then
     tar -xf /tmp/aur.tar.gz -C /tmp
     mkdir library
     mv /tmp/ansible-aur-0.24/aur.py ./library
-    ln -s ansible ansible-$ANSIBLE_VERSION/ansible-playbook
+    ln -s ansible $ANSIBLE_FOLDER/ansible-playbook
 else
-    echo "Ansible found in $OUT_FOLDER/ansible-$ANSIBLE_VERSION, skipping installation..."
+    echo "Ansible found in $OUT_FOLDER/$ANSIBLE_FOLDER, skipping installation..."
 fi
 
 # Orchestration
 echo "Starting Hanzo orchestration..."
-PYTHONPATH=ansible-$ANSIBLE_VERSION python ansible-$ANSIBLE_VERSION/ansible-playbook orchestrate.yml --connection=local --tags=$TAGS
+PYTHONPATH=$ANSIBLE_FOLDER python $ANSIBLE_FOLDER/ansible-playbook orchestrate.yml --connection=local --tags=$TAGS
 
 # Post-install script
-echo "=================="
-echo "Post-install steps"
-echo "=================="
-
-passwd $HANZO_USERNAME
+echo "Executing post-install steps..."
 chsh -s /bin/zsh $HANZO_USERNAME

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -75,7 +75,7 @@ fi
 
 # Orchestration
 echo "Starting Hanzo orchestration..."
-PYTHONPATH=$ANSIBLE_FOLDER python $ANSIBLE_FOLDER/ansible-playbook orchestrate.yml --connection=local --tags=$TAGS
+PYTHONPATH=$ANSIBLE_FOLDER python $ANSIBLE_FOLDER/ansible-playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
 
 # Post-install script
 echo "Executing post-install steps..."


### PR DESCRIPTION
### Overview

Closes #141 

This PR improves Hanzo test suite with the following changes:
* `Dockerfile` is not used only for local testing
* `bootstrap.sh` is now used both by `Dockerfile` and CircleCI runners, so that the real process is tested without any duplication
* CircleCI runs the script directly, instead of building the container via `Dockerfile`. This improves the test execution, without committing changes at the last step of the build.

**Overall test execution:**
* Pre-changes: 11 minutes
* Post-changes: 8 minutes