### PR TITLE
Remove `openssl-1.0` used to build Python 3.4

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -19,7 +19,6 @@
       - ntp
       - openssh
       - openssl
-      - openssl-1.0
       - p7zip
       - sudo
       - tar


### PR DESCRIPTION
### Overview

Python 3.4 required a legacy version of OpenSSL (`openssl-1.0` package in Archlinux). This change was introduce with #156, but because Python 3.4 is EOL and not used in my systems, we can safely remove the package.