### PR TITLE
[tasks/system] add speetest-cli tool

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -20,6 +20,7 @@
       - openssh
       - openssl
       - p7zip
+      - speedtest-cli
       - sudo
       - tar
       - tree


### PR DESCRIPTION
### Overview

Adds `speedtest-cli` tool to check Internet speed from the command line.