### PR TITLE
Add Google Chrome Beta

### DIFF
--- a/roles/extras/tasks/main.yml
+++ b/roles/extras/tasks/main.yml
@@ -15,3 +15,10 @@
       - ncmpcpp
       - transmission-cli
       - youtube-dl
+
+- name: Installing Google Chrome Beta
+  aur:
+    name:
+      - google-chrome-beta
+  become: yes
+  become_user: aur_builder


### PR DESCRIPTION
### Overview

For local development, Google Chrome is used. Because the main browser is Firefox, using the beta is fine to access to the latest tools.