### PR TITLE
Release the container package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,12 @@
 name: release
 
 on:
-  pull_request:
-    
-  # Commented out for testing purposes
-  # push:
-  #   branches:
-  #     - master
-  # schedule:
-  #   # Run every day at 1.00am
-  #   - cron:  '0 1 * * *'
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every day at 1.00am
+    - cron:  '0 1 * * *'
 
 jobs:
   build-container:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  pull_request:
+    
+  # Commented out for testing purposes
+  # push:
+  #   branches:
+  #     - master
+  # schedule:
+  #   # Run every day at 1.00am
+  #   - cron:  '0 1 * * *'
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Builds and push the container to Github Package Registry.
+      # Environment variables are tailored for my use case and
+      # are not meant to be generic.
+      - name: Build container for Fedora Toolbox
+        uses: elgohr/Publish-Docker-Github-Action@2.13
+        env:
+          HANZO_FULLNAME: 'Emanuele Palazzetti'
+          HANZO_USERNAME: 'palazzem'
+          HANZO_EMAIL: 'emanuele.palazzetti@gmail.com'
+        with:
+          name: docker.pkg.github.com/palazzem/hanzo/archlinux
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          buildargs: HANZO_FULLNAME,HANZO_USERNAME,HANZO_EMAIL
+          snapshot: true
+          tags: 'latest'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM archlinux/base
-LABEL maintainer="hello@palazzetti.me"
+FROM docker.io/palazzem/archlinux-toolbox:latest
+LABEL maintainer="Emanuele Palazzetti <emanuele.palazzetti@gmail.com>"
 
-# Configure testing environment
-ARG TAGS
-ENV EXTRA_ARGS --verbose
-ENV HANZO_FULLNAME test
-ENV HANZO_USERNAME test
-ENV HANZO_EMAIL test@example.com
-ENV HANZO_FOLDER /root/hanzo
+# Configure the build environment
+ENV HANZO_FOLDER /root/.hanzo
+ARG HANZO_FULLNAME
+ARG HANZO_USERNAME
+ARG HANZO_EMAIL
 
-COPY . /root/hanzo
-WORKDIR /root/hanzo
+# Push the repository in Hanzo default folder
+COPY . /root/.hanzo
+WORKDIR /root/.hanzo
 
-# Provisioning at build time so that if a container builds correctly,
-# the test is successful
+# Provisioning at build time
 RUN bash bin/bootstrap.sh

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ Hanzō
 
 .. image:: https://github.com/palazzem/hanzo/workflows/test/badge.svg
     :target: https://github.com/palazzem/hanzo/actions?query=workflow%3Atest
+.. image:: https://github.com/palazzem/hanzo/workflows/release/badge.svg
+    :target: https://github.com/palazzem/hanzo/actions?query=workflow%3Arelease
 
 This `Ansible`_ playbook configures a new ArchLinux installation with some development tools. The goal of the
 playbook is *inspiring developers* to prepare programmatically their development environment. This repository targets

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,11 @@ If you want to apply the playbook changes without touching your current configur
 change of the current configuration, a ``Dockerfile`` is available to build an ArchLinux container. To start the
 provisioning, just::
 
-   $ docker build -t hanzo:test . && docker rmi hanzo:test
+   $ docker build . -t hanzo:test \
+       --build-arg HANZO_FULLNAME=test \
+       --build-arg HANZO_USERNAME=test \
+       --build-arg HANZO_EMAIL=test@example.com && \
+       docker rmi hanzo:test
 
 Contribute
 ----------


### PR DESCRIPTION
### Overview

Closes #186 

This PR uses GitHub to build and release a container package. The package is based on `docker.io/palazzem/archlinux-toolbox:latest` [image](https://github.com/palazzem/archlinux-toolbox/), ready to be used on Fedora Silverblue.

The package is built:
* After every `master` merge
* Nightly at 1.00am