### PR TITLE
Drop some packages

### DIFF
--- a/roles/development/tasks/javascript.yml
+++ b/roles/development/tasks/javascript.yml
@@ -7,11 +7,3 @@
     state: latest
     name:
       - nodejs
-
-- name: Installing 'nodenv'
-  aur:
-    name:
-      - nodenv
-      - nodenv-node-build-git
-  become: yes
-  become_user: aur_builder

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -9,7 +9,6 @@
       - cmake
       - gdb
       - git
-      - mercurial
       - sqlite
 
 - name: Configuring .gitconfig

--- a/roles/development/tasks/ruby.yml
+++ b/roles/development/tasks/ruby.yml
@@ -6,11 +6,3 @@
   pacman:
     state: latest
     name: ruby
-
-- name: Installing 'rbenv'
-  aur:
-    name:
-      - rbenv
-      - ruby-build
-  become: yes
-  become_user: aur_builder

--- a/roles/editors/tasks/neovim.yml
+++ b/roles/editors/tasks/neovim.yml
@@ -7,4 +7,3 @@
     state: latest
     name:
       - neovim
-      - python-neovim

--- a/roles/extras/tasks/main.yml
+++ b/roles/extras/tasks/main.yml
@@ -6,27 +6,5 @@
   pacman:
     state: latest
     name:
-      - gimp
-      - imagemagick
-      - libreoffice-en-US
-      - libreoffice-fresh
-      - mopidy
-      - mpv
-      - ncmpcpp
       - transmission-cli
       - youtube-dl
-
-- name: Installing consumer applications (AUR)
-  aur:
-    name:
-      - mopidy-mpd
-      - mopidy-spotify
-  become: yes
-  become_user: aur_builder
-
-- name: Installing Google Chrome Beta
-  aur:
-    name:
-      - google-chrome-beta
-  become: yes
-  become_user: aur_builder


### PR DESCRIPTION
### Overview

This PR removes the following packages:

- nodenv
- rbenv
- python-neovim
- mercurial
- Consumer apps (e.g. Google Chrome Beta, Libreoffice, etc...)