### PR TITLE
Update Hanzo to use ansible-core

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: archlinux:latest
+      image: archlinux:base-devel
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/palazzem/archlinux-toolbox:latest
+FROM archlinux:base-devel
 LABEL maintainer="Emanuele Palazzetti <emanuele.palazzetti@gmail.com>"
 
 # Configure the build environment

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -45,6 +45,14 @@ HANZO_FULLNAME=${HANZO_FULLNAME:-$(get_env "Provide your full name:")}; export H
 HANZO_USERNAME=${HANZO_USERNAME:-$(get_env "Provide your username:")}; export HANZO_USERNAME
 HANZO_EMAIL=${HANZO_EMAIL:-$(get_env "Provide your email:")}; export HANZO_EMAIL
 
+# Install dependencies
+echo "Installing dependencies..."
+pacman -Sy --noconfirm \
+  git \
+  tar \
+  python \
+  python-pip
+
 # Install/Update Hanzo unless a folder is specified
 if [[ -z "${HANZO_FOLDER}" ]]; then
     echo "Downloading/Updating Hanzo..."

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -31,7 +31,7 @@ set -e
 
 # Variables
 REPOSITORY=https://github.com/palazzem/hanzo.git
-OUT_FOLDER=/root/.hanzo/
+OUT_FOLDER=/root/.hanzo
 
 # Helper functions
 

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -30,8 +30,6 @@
 set -e
 
 # Variables
-ANSIBLE_VERSION=2.14.3
-ANSIBLE_FOLDER="ansible-$ANSIBLE_VERSION"
 REPOSITORY=https://github.com/palazzem/hanzo.git
 OUT_FOLDER=/root/.hanzo/
 
@@ -58,24 +56,21 @@ fi
 
 cd "$OUT_FOLDER"
 
-# Install Ansible Portable if not available
-if [ ! -d "$OUT_FOLDER/$ANSIBLE_FOLDER" ]; then
-    echo "Installing Ansible Portable..."
-    pacman -Sy tar python --noconfirm
-    curl -L https://github.com/palazzem/ansible-portable/releases/download/$ANSIBLE_VERSION/ansible-$ANSIBLE_VERSION.tar.gz > /tmp/ansible.tar.gz
+# Install Ansible
+if [ ! -d "$OUT_FOLDER/library" ]; then
+    echo "Installing Ansible..."
+    pacman -Sy tar ansible --noconfirm
     curl -L https://github.com/kewlfft/ansible-aur/archive/v0.24.tar.gz > /tmp/aur.tar.gz
-    tar -xf /tmp/ansible.tar.gz
     tar -xf /tmp/aur.tar.gz -C /tmp
     mkdir library
     mv /tmp/ansible-aur-0.24/aur.py ./library
-    ln -s ansible $ANSIBLE_FOLDER/ansible-playbook
 else
-    echo "Ansible found in $OUT_FOLDER/$ANSIBLE_FOLDER, skipping installation..."
+    echo "Ansible extensions found in $OUT_FOLDER/library, skipping installation..."
 fi
 
 # Orchestration
 echo "Starting Hanzo orchestration..."
-PYTHONPATH=$ANSIBLE_FOLDER python $ANSIBLE_FOLDER/ansible-playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
+ansible playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
 
 # Post-install script
 echo "Executing post-install steps..."

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -67,9 +67,7 @@ cd "$OUT_FOLDER"
 
 # Install Ansible and configure collections
 pip install ansible-core --user
-# TODO: move to a collection.yml file
-$ANSIBLE_FOLDER/ansible-galaxy collection install community.general
-$ANSIBLE_FOLDER/ansible-galaxy collection install kewlfft.aur
+$ANSIBLE_FOLDER/ansible-galaxy collection install -r requirements.yml
 
 # Orchestration
 echo "Starting Hanzo orchestration..."

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -30,7 +30,7 @@
 set -e
 
 # Variables
-ANSIBLE_VERSION=2.9.2
+ANSIBLE_VERSION=2.14.3
 ANSIBLE_FOLDER="ansible-$ANSIBLE_VERSION"
 REPOSITORY=https://github.com/palazzem/hanzo.git
 OUT_FOLDER=/root/.hanzo/

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -70,7 +70,7 @@ fi
 
 # Orchestration
 echo "Starting Hanzo orchestration..."
-ansible playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
+ansible-playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
 
 # Post-install script
 echo "Executing post-install steps..."

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -31,6 +31,7 @@ set -e
 
 # Variables
 REPOSITORY=https://github.com/palazzem/hanzo.git
+ANSIBLE_FOLDER=$HOME/.local/bin
 OUT_FOLDER=/root/.hanzo
 
 # Helper functions
@@ -64,21 +65,15 @@ fi
 
 cd "$OUT_FOLDER"
 
-# Install Ansible
-if [ ! -d "$OUT_FOLDER/library" ]; then
-    echo "Installing Ansible..."
-    pacman -Sy tar ansible --noconfirm
-    curl -L https://github.com/kewlfft/ansible-aur/archive/v0.24.tar.gz > /tmp/aur.tar.gz
-    tar -xf /tmp/aur.tar.gz -C /tmp
-    mkdir library
-    mv /tmp/ansible-aur-0.24/aur.py ./library
-else
-    echo "Ansible extensions found in $OUT_FOLDER/library, skipping installation..."
-fi
+# Install Ansible and configure collections
+pip install ansible-core --user
+# TODO: move to a collection.yml file
+$ANSIBLE_FOLDER/ansible-galaxy collection install community.general
+$ANSIBLE_FOLDER/ansible-galaxy collection install kewlfft.aur
 
 # Orchestration
 echo "Starting Hanzo orchestration..."
-ansible-playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
+$ANSIBLE_FOLDER/ansible-playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
 
 # Post-install script
 echo "Executing post-install steps..."

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+---
+# Install a collection from Ansible Galaxy.
+
+collections:
+  - community.general
+  - kewlfft.aur

--- a/roles/aur/tasks/main.yml
+++ b/roles/aur/tasks/main.yml
@@ -12,7 +12,6 @@
     path: /etc/sudoers.d/11-install-aur_builder
     line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'
     create: yes
-    validate: 'visudo -cf %s'
 
 - name: Install 'yay' AUR helper
   kewlfft.aur.aur:

--- a/roles/aur/tasks/main.yml
+++ b/roles/aur/tasks/main.yml
@@ -15,9 +15,9 @@
     validate: 'visudo -cf %s'
 
 - name: Install 'yay' AUR helper
-  aur:
+  kewlfft.aur.aur:
     name: yay
     use: makepkg
-    skip_installed: true
+    state: present
   become: yes
   become_user: aur_builder

--- a/roles/development/tasks/python.yml
+++ b/roles/development/tasks/python.yml
@@ -8,6 +8,7 @@
     name:
       - python
       - python-pip
+      - python-setuptools
 
 - name: Installing 'pyenv'
   aur:

--- a/roles/development/tasks/python.yml
+++ b/roles/development/tasks/python.yml
@@ -11,7 +11,8 @@
       - python-setuptools
 
 - name: Installing 'pyenv'
-  aur:
+  kewlfft.aur.aur:
+    use: yay
     name: pyenv
   become: yes
   become_user: aur_builder

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: Installing Security Packages (AUR)
   become: yes
   become_user: aur_builder
-  aur:
+  kewlfft.aur.aur:
+    use: yay
     name:
       - openvpn-update-systemd-resolved

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -35,7 +35,8 @@
 - name: Installing system packages (AUR)
   become: yes
   become_user: aur_builder
-  aur:
+  kewlfft.aur.aur:
+    use: yay
     name:
       - downgrade
 


### PR DESCRIPTION
### Overview

Removes https://github.com/palazzem/ansible-portable in favor of `ansible-core`.
Other changes are needed to support the latest Ansible version.