### PR TITLE
Update Hanzo to address some warnings

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Copyright (c) 2014-2020, Emanuele Palazzetti and contributors
+# Copyright (c) 2014-2023, Emanuele Palazzetti and contributors
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -70,12 +70,12 @@ fi
 cd "$HANZO_FOLDER"
 
 # Install Ansible and configure collections
-pip install ansible-core --user
-$ANSIBLE_FOLDER/ansible-galaxy collection install -r requirements.yml
+pip install ansible-core --target $ANSIBLE_FOLDER --progress-bar off
+PYTHONPATH=$ANSIBLE_FOLDER $ANSIBLE_FOLDER/bin/ansible-galaxy collection install -r requirements.yml
 
 # Orchestration
 echo "Starting Hanzo orchestration..."
-$ANSIBLE_FOLDER/ansible-playbook orchestrate.yml --connection=local --tags=$TAGS $EXTRA_ARGS
+PYTHONPATH=$ANSIBLE_FOLDER $ANSIBLE_FOLDER/bin/ansible-playbook orchestrate.yml --connection=local --inventory inventory.yml --tags=$TAGS $EXTRA_ARGS
 
 # Post-install script
 echo "Executing post-install steps..."

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -55,7 +55,6 @@ ANSIBLE_FOLDER="$BUILD_FOLDER/ansible"
 echo "Installing dependencies..."
 pacman -Sy --noconfirm \
   git \
-  tar \
   python \
   python-pip
 

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,0 +1,4 @@
+all:
+  
+  hosts:
+    localhost

--- a/orchestrate.yml
+++ b/orchestrate.yml
@@ -4,6 +4,8 @@
 
 - hosts: localhost
   name: Hanzo Lookup
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   tags: always
   tasks:
     - name: Configure the environment
@@ -22,6 +24,8 @@
 
 - hosts: localhost
   name: Archlinux/toolbox
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   tags: always
   become: yes
   tasks:

--- a/orchestrate.yml
+++ b/orchestrate.yml
@@ -6,6 +6,7 @@
   name: Hanzo Lookup
   vars:
     ansible_python_interpreter: /usr/bin/python3
+    ansible_remote_tmp: "{{ lookup('env', 'ANSIBLE_FOLDER') }}/tmp"
   tags: always
   tasks:
     - name: Configure the environment
@@ -26,6 +27,7 @@
   name: Archlinux/toolbox
   vars:
     ansible_python_interpreter: /usr/bin/python3
+    ansible_remote_tmp: "{{ lookup('env', 'ANSIBLE_FOLDER') }}/tmp"
   tags: always
   become: yes
   tasks:

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -11,4 +11,3 @@
       - base-devel
       - linux
       - linux-headers
-

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -2,4 +2,4 @@
 
 # Cluster management tools
 
-- include: gcloud.yml
+- ansible.builtin.include_tasks: gcloud.yml

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -15,8 +15,8 @@
   template: src=gitconfig.j2 dest="/home/{{username}}/.gitconfig" owner={{username}} group={{username}} mode=0644
 
 # Supported Languages
-- include: go.yml
-- include: java.yml
-- include: javascript.yml
-- include: python.yml
-- include: ruby.yml
+- ansible.builtin.include_tasks: go.yml
+- ansible.builtin.include_tasks: java.yml
+- ansible.builtin.include_tasks: javascript.yml
+- ansible.builtin.include_tasks: python.yml
+- ansible.builtin.include_tasks: ruby.yml

--- a/roles/editors/tasks/main.yml
+++ b/roles/editors/tasks/main.yml
@@ -2,6 +2,6 @@
 
 # Code Editors
 
-- include: neovim.yml
-- include: emacs.yml
-- include: code.yml
+- ansible.builtin.include_tasks: neovim.yml
+- ansible.builtin.include_tasks: emacs.yml
+- ansible.builtin.include_tasks: code.yml

--- a/roles/orchestrators/tasks/main.yml
+++ b/roles/orchestrators/tasks/main.yml
@@ -2,4 +2,4 @@
 
 # Containers tools
 
-- include: docker.yml
+- ansible.builtin.include_tasks: docker.yml


### PR DESCRIPTION
### Overview

Fixes the following warnings:

```bash
WARNING: The scripts ansible, ansible-config, ansible-connection, ansible-console, ansible-doc, ansible-galaxy, ansible-inventory, ansible-playbook, ansible-pull and ansible-vault are installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
```

```bash
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
```

```bash
[WARNING]: Module remote_tmp /home/aur_builder/.ansible/tmp did not exist and
was created with a mode of 0700, this may cause issues when running as another
user. To avoid this, create the remote_tmp dir with the correct permissions
manually
```

```bash
[WARNING]: Module remote_tmp /home/test/.ansible/tmp did not exist and was
created with a mode of 0700, this may cause issues when running as another
user. To avoid this, create the remote_tmp dir with the correct permissions
manually
```

```bash
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks
instead. See https://docs.ansible.com/ansible-
core/2.14/user_guide/playbooks_reuse_includes.html for details. This feature
will be removed in version 2.16. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg
```