### PR TITLE
Set tty permission required by GPG interface

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -69,3 +69,13 @@
     dest: /etc/pacman.conf
     regexp: "^#Color"
     replace: "Color"
+
+- name: Detect tty file path
+  shell: tty
+  register: tty_path
+
+- name: Change ownership of tty device
+  file:
+    path: "{{ tty_path.stdout }}"
+    owner: "{{username}}"
+    group: "tty"


### PR DESCRIPTION
### Overview

Equivalent of:
```bash
$ chown user:tty $(tty)
```

This is required to fix terminal permissions when using GPG.