### PR TITLE
ci: GitHub actions use the same documented build process

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,18 +11,12 @@ jobs:
   arch-linux:
     runs-on: ubuntu-latest
 
-    container:
-      image: archlinux:base-devel
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Run Hanzo
-        env:
-          EXTRA_ARGS: '--verbose'
-          HANZO_FULLNAME: 'test'
-          HANZO_USERNAME: 'test'
-          HANZO_EMAIL: 'test@example.com'
-          HANZO_FOLDER: '.'
-        run: bash bin/bootstrap.sh
+      - name: Build Arch Linux container with Hanzo
+        run: docker build . -t hanzo:test
+              --build-arg HANZO_FULLNAME=test
+              --build-arg HANZO_USERNAME=test
+              --build-arg HANZO_EMAIL=test@example.com


### PR DESCRIPTION
### Overview

Instead of using different instructions, GitHub Actions now use the same build script that is documented and used during development.