### PR TITLE
ci: implement nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,19 @@
+name: Nightly builds
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+jobs:
+  arch-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Arch Linux container with Hanzo
+        run: docker build . -t hanzo:test
+              --build-arg HANZO_FULLNAME=test
+              --build-arg HANZO_USERNAME=test
+              --build-arg HANZO_EMAIL=test@example.com


### PR DESCRIPTION
### Overview

Run nightly builds every day at 2AM. The goal is to detect early when a development container cannot be built.