### PR TITLE
feat: add postgresql-libs to support libraries that expect pg_config

### DIFF
--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -8,6 +8,7 @@
       - gdb
       - git
       - jq
+      - postgresql-libs
       - sqlite
       - yq
 


### PR DESCRIPTION
### Overview

Libraries such as `psycopg2` requires `pg_config` and all libraries available in this package.