### PR TITLE
feat!: `wheel` group doesn't require password

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -52,8 +52,11 @@
 - name: Creating 'workspaces' folder
   file: path="/home/{{username}}/workspaces" owner={{username}} group={{username}} state=directory
 
-- name: Adding 'wheel' group to sudoers
-  lineinfile: "dest=/etc/sudoers state=present regexp='^%wheel' line='%wheel ALL=(ALL) ALL'"
+- name: Adding 'wheel' group to sudoers without password
+  # There is no need to set a password to get `root` permissions in a development box that is entirely
+  # disposable and meant for 1 user only. Furthermore, the box runs in a container started with a `sysbox-runc`
+  # isolation and gaining `root` permissions has no implications in the main host.
+  lineinfile: "dest=/etc/sudoers state=present regexp='^%wheel' line='%wheel ALL=(ALL:ALL) NOPASSWD: ALL'"
 
 - name: Set en_US.UTF8 locale
   replace:


### PR DESCRIPTION
## Overview

- `wheel` group does not require a password anymore to gain `root` permissions.

## Notes

There is no need to set a password to get `root` permissions in a development box that is entirely disposable and meant for 1 user only. Furthermore, the box runs in a container started with a `sysbox-runc` isolation and gaining `root` permissions has no implications in the main host.