### PR TITLE
feat: add direnv to quickly switch env variables across monorepos

### DIFF
--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -5,6 +5,7 @@
   pacman:
     state: latest
     name:
+      - direnv
       - gdb
       - git
       - jq


### PR DESCRIPTION
### Overview

- Add `direnv` to load `.envrc` files 