### PR TITLE
fix(python): use system python-pipx to honor PEP 668

### DIFF
--- a/roles/development/tasks/python.yml
+++ b/roles/development/tasks/python.yml
@@ -8,6 +8,7 @@
     name:
       - python
       - python-pip
+      - python-pipx
       - python-setuptools
 
 - name: Installing 'pyenv'
@@ -16,15 +17,6 @@
     name: pyenv
   become: yes
   become_user: aur_builder
-
-- name: Installing Python isolated environments (pipx)
-  ansible.builtin.pip:
-    state: latest
-    extra_args: --user
-    name:
-      - pipx
-  become: yes
-  become_user: "{{ username }}"
 
 - name: Installing Python tools - ipython
   community.general.pipx:


### PR DESCRIPTION
### Bug

Failing job: https://github.com/palazzem/hanzo/actions/runs/5262470093/jobs/9523058544

```
TASK [development : Installing Python isolated environments (pipx)] ************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": ["/usr/bin/python3", "-m", "pip.__main__", "install", "-U", "--user", "pipx"], "msg": "\n:stderr: error: externally-managed-environment\n\n× This environment is externally managed\n╰─> To install Python packages system-wide, try 'pacman -S\n    python-xyz', where xyz is the package you are trying to\n    install.\n    \n    If you wish to install a non-Arch-packaged Python package,\n    create a virtual environment using 'python -m venv path/to/venv'.\n    Then use path/to/venv/bin/python and path/to/venv/bin/pip.\n    \n    If you wish to install a non-Arch packaged Python application,\n    it may be easiest to use 'pipx install xyz', which will manage a\n    virtual environment for you. Make sure you have python-pipx\n    installed via pacman.\n\nnote: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.\nhint: See PEP 668 for the detailed specification.\n"}
```

### Overview

This error is due to the fact Archlinux honors [PEP668](https://peps.python.org/pep-0668/) and now installing Python packages using `python3 -m pip install x.y.z` is not working anymore.

This change uses `python-pipx` as suggested by ArchLinux itself.