### PR TITLE
fix(bootstrap): force a system update before installing Hanzo

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -51,6 +51,10 @@ echo "Using BUILD_FOLDER: $BUILD_FOLDER"
 REPOSITORY="https://github.com/palazzem/hanzo.git"
 ANSIBLE_FOLDER="$BUILD_FOLDER/ansible"
 
+# System update
+echo "Updating system Arch Linux..."
+pacman -Syu --noconfirm
+
 # Install dependencies
 echo "Installing dependencies..."
 pacman -Sy --noconfirm \


### PR DESCRIPTION
### Overview

Fixes an issue that prevents the system to run because GLIBC was missing. This regression has been introduced as Hanzo didn't take in consideration possible changes in `archlinux:base-devel` container. The reported issue was
```bash
# While building the Hanzo container
# [...]
(4/4) Warn about old perl modules
WARNING: '/usr/lib/perl5/5.38' contains data from at least 3 packages which will NOT be used by the installed perl interpreter.
 -> Run the following command to get a list of affected packages: pacman -Qqo '/usr/lib/perl5/5.38'

Downloading/Updating Hanzo...
sh: line 63: cd: /tmp/tmp.5UpXDaRZjD/hanzo: No such file or directory
```

`/tmp/tmp.5UpXDaRZjD/hanzo` folder didn't exist because `git` was failing with error:
```bash
sh-5.1# git
git: /usr/lib/libc.so.6: version `GLIBC_2.38' not found (required by git)
```

Updating the system before running Hanzo, solved the problem.