### PR TITLE
fix: use yt-dlp fork instead of original youtube-dl

### DIFF
--- a/roles/extras/tasks/main.yml
+++ b/roles/extras/tasks/main.yml
@@ -7,4 +7,4 @@
     state: latest
     name:
       - transmission-cli
-      - youtube-dl
+      - yt-dlp


### PR DESCRIPTION
### Overview

`youtube-dl` is stagnant (last release 2021) and removed from ArchLinux extras. `yt-dlp` is the new package to use.