### PR TITLE
feat: add docker-buildx package

### DIFF
--- a/roles/orchestrators/tasks/docker.yml
+++ b/roles/orchestrators/tasks/docker.yml
@@ -8,6 +8,7 @@
     name:
       - docker
       - docker-compose
+      - docker-buildx
 
 - name: Adding default user to docker group
   user: name={{username}} groups=docker append=yes


### PR DESCRIPTION
### Overview

Add `docker-buildx` to use the new builder.

#### Warning Message

```
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/
```