### PR TITLE
fix: replace `archey3` with `neofetch`

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -5,7 +5,6 @@
   pacman:
     state: latest
     name:
-      - archey3
       - curl
       - dnsutils
       - dosfstools
@@ -18,6 +17,7 @@
       - less
       - mlocate
       - mono
+      - neofetch
       - ntfsprogs
       - ntp
       - openssh


### PR DESCRIPTION
Rationale: `archey3` is not available in `[extra]` anymore. Both are not maintained but whatever works just to have a nice entry screen.