### PR TITLE
feat(modules): add packages.sh and system.sh modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ venv.bak/
 # IDE
 .idea/
 .vscode/
+
+# Worktrees
+.worktrees/

--- a/modules/packages.sh
+++ b/modules/packages.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2014-2025, Emanuele Palazzetti and contributors
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+set -e
+
+# Colors for better visual output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "ℹ️  ${GREEN}$1${NC}"
+}
+
+log_warn() {
+    echo -e "⚠️  ${YELLOW}$1${NC}"
+}
+
+log_error() {
+    echo -e "❌ ${RED}$1${NC}"
+}
+
+log_success() {
+    echo -e "✅ ${GREEN}$1${NC}"
+}
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Layer 1: System base packages
+install_system_base() {
+    log_info "Installing system base packages..."
+
+    local packages=(
+        # Core tools
+        base-devel
+        git
+        fzf
+        htop
+        neovim
+        fastfetch
+        tree
+        wget
+        jq
+        yq
+        httpie
+        openssl
+        gettext
+        gdb
+        plocate
+        procps-ng
+        sudo
+        bind
+        whois
+        tmux
+        # Docker stack
+        docker
+        docker-buildx
+        docker-compose
+        # Archive
+        p7zip
+        unrar
+        # AI/ML
+        ollama-rocm
+        # Audio firmware
+        sof-firmware
+        # ASUS tools
+        asusctl
+        rog-control-center
+    )
+
+    sudo pacman -S --needed --noconfirm "${packages[@]}"
+    log_success "System base packages installed"
+}
+
+# Layer 2: Language runtimes
+install_runtimes() {
+    log_info "Installing language runtimes..."
+
+    local packages=(
+        rustup
+        go
+    )
+
+    sudo pacman -S --needed --noconfirm "${packages[@]}"
+    log_success "Language runtimes installed"
+}
+
+# Layer 6: Gaming and multimedia
+install_gaming() {
+    log_info "Installing gaming and multimedia packages..."
+
+    local packages=(
+        cachyos-gaming-applications
+        ffmpeg
+        gst-plugins-good
+        gst-plugins-bad
+        gst-plugins-ugly
+        gst-libav
+    )
+
+    sudo pacman -S --needed --noconfirm "${packages[@]}"
+    log_success "Gaming and multimedia packages installed"
+}
+
+# AUR packages via paru
+install_aur_packages() {
+    if ! command_exists paru; then
+        log_error "paru is not installed. Install paru first to manage AUR packages."
+        exit 1
+    fi
+
+    log_info "Installing AUR packages..."
+    # --noconfirm intentionally skips PKGBUILD review because the AUR package
+    # list is curated and vetted at plan time, not chosen dynamically at runtime.
+    paru -S --needed --noconfirm fnm-bin
+    log_success "AUR packages installed"
+}
+
+# GPU drivers via hardware detection
+install_gpu_drivers() {
+    if ! command_exists chwd; then
+        log_error "chwd is not installed. Cannot auto-detect GPU drivers."
+        exit 1
+    fi
+
+    log_info "Auto-detecting and installing GPU drivers..."
+    sudo chwd -a
+    log_success "GPU drivers installed"
+}
+
+# Main
+main() {
+    log_info "Starting package installation..."
+
+    install_system_base
+    install_runtimes
+    install_gaming
+    install_aur_packages
+    install_gpu_drivers
+
+    log_success "All packages installed successfully"
+}
+
+main "$@"

--- a/modules/system.sh
+++ b/modules/system.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2014-2025, Emanuele Palazzetti and contributors
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+set -e
+
+# Colors for better visual output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "ℹ️  ${GREEN}$1${NC}"
+}
+
+log_warn() {
+    echo -e "⚠️  ${YELLOW}$1${NC}"
+}
+
+log_error() {
+    echo -e "❌ ${RED}$1${NC}"
+}
+
+log_success() {
+    echo -e "✅ ${GREEN}$1${NC}"
+}
+
+# Add current user to a group if not already a member
+ensure_group_membership() {
+    local group="$1"
+
+    if id -nG "$USER" | grep -qw "$group"; then
+        log_info "User $USER is already a member of group '$group'"
+    else
+        log_info "Adding user $USER to group '$group'..."
+        sudo usermod -aG "$group" "$USER"
+        log_success "User $USER added to group '$group'"
+    fi
+}
+
+# Enable and start a systemd service if not already enabled
+ensure_service_enabled() {
+    local service="$1"
+
+    if systemctl is-enabled --quiet "$service" 2>/dev/null; then
+        log_info "Service '$service' is already enabled"
+    else
+        log_info "Enabling service '$service'..."
+        sudo systemctl enable "$service"
+        sudo systemctl start "$service" 2>/dev/null || log_warn "Service '$service' enabled but could not be started (will start on next boot)"
+        log_success "Service '$service' enabled and started"
+    fi
+}
+
+# Ensure locale is generated and set
+configure_locale() {
+    local target_locale="en_US.UTF-8"
+
+    # Check if locale is already generated
+    if locale -a 2>/dev/null | grep -qi "en_US.utf8"; then
+        log_info "Locale $target_locale is already generated"
+    else
+        log_info "Generating locale $target_locale..."
+
+        # Uncomment the locale in /etc/locale.gen if it's commented out
+        if grep -q "^#\s*${target_locale}" /etc/locale.gen; then
+            sudo sed -i "s/^#\s*\(${target_locale}\)/\1/" /etc/locale.gen
+        fi
+
+        sudo locale-gen
+        log_success "Locale $target_locale generated"
+    fi
+
+    # Ensure /etc/locale.conf has the correct LANG
+    if grep -q "^LANG=${target_locale}$" /etc/locale.conf 2>/dev/null; then
+        log_info "Locale configuration is already set to $target_locale"
+    else
+        log_info "Setting system locale to $target_locale..."
+        echo "LANG=${target_locale}" | sudo tee /etc/locale.conf >/dev/null
+        log_success "System locale set to $target_locale"
+    fi
+}
+
+# User groups
+configure_groups() {
+    log_info "Configuring user group memberships..."
+
+    ensure_group_membership docker
+    ensure_group_membership render
+    ensure_group_membership video
+
+    log_success "User group memberships configured"
+}
+
+# Systemd services
+configure_services() {
+    log_info "Configuring systemd services..."
+
+    ensure_service_enabled docker
+    ensure_service_enabled ollama
+    ensure_service_enabled asusd
+
+    log_success "Systemd services configured"
+}
+
+# Main
+main() {
+    log_info "Starting system configuration..."
+
+    configure_groups
+    configure_services
+    configure_locale
+
+    log_success "System configuration complete"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Closes #222

Adds the first two modules in Hanzo's CachyOS provisioner pipeline:

- **`modules/packages.sh`** -- Installs all packages across four categories (pacman base, pacman runtimes, pacman gaming, AUR via paru) plus GPU driver auto-detection via `chwd`. Uses minimal pacman transactions (`--needed --noconfirm`) to reduce Btrfs snapshot overhead. Each category is isolated in its own function for clarity and failure isolation.

- **`modules/system.sh`** -- Configures post-install system settings: user group memberships (docker, render, video), systemd service enablement (docker, ollama, asusd), and en_US.UTF-8 locale generation. All operations check current state before acting for idempotency.

Both scripts follow existing codebase conventions (BSD-2-Clause header, `set -e`, colored log functions, emoji-prefixed status messages) and are safe to re-run.

## Test plan

- [ ] Verify both scripts parse cleanly with `bash -n modules/packages.sh` and `bash -n modules/system.sh`
- [ ] Verify both files are executable (`ls -la modules/`)
- [ ] Run shellcheck if available: `shellcheck modules/packages.sh modules/system.sh`
- [ ] Test on a CachyOS system or via the CI Containerfile build