### PR TITLE
feat(tasks): add system.py for groups, services, and locale

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -41,7 +41,7 @@ if os.path.isfile(_config_path):
 local.include("tasks/packages.py")
 
 # Phase 2 tasks (uncomment as they land):
-# local.include("tasks/system.py")
+local.include("tasks/system.py")
 # local.include("tasks/tools.py")
 # local.include("tasks/dotfiles.py")
 

--- a/group_data/all.py
+++ b/group_data/all.py
@@ -55,3 +55,30 @@ gaming_packages = [
 aur_packages = [
     "fnm-bin",
 ]
+
+# ---------------------------------------------------------------------------
+# System configuration (tasks/system.py)
+# ---------------------------------------------------------------------------
+
+# Groups that must be created as system groups before user membership.
+# render and video are kernel/udev-managed and always exist.
+system_groups = [
+    "docker",
+]
+
+# Supplementary groups to add the current user to.
+user_groups = [
+    "docker",
+    "render",
+    "video",
+]
+
+# Systemd services to enable at boot and start.
+system_services = [
+    "docker",
+    "ollama",
+    "asusd",
+]
+
+# System locale.
+system_locale = "en_US.UTF-8"

--- a/group_data/all.py
+++ b/group_data/all.py
@@ -60,15 +60,15 @@ aur_packages = [
 # System configuration (tasks/system.py)
 # ---------------------------------------------------------------------------
 
-# Groups that must be created as system groups before user membership.
+# Only groups not managed by the kernel or package scripts.
 # render and video are kernel/udev-managed and always exist.
 system_groups = [
     "docker",
 ]
 
 # Supplementary groups to add the current user to.
-user_groups = [
-    "docker",
+# Includes system_groups (which we create) plus kernel-managed groups.
+user_groups = system_groups + [
     "render",
     "video",
 ]
@@ -80,5 +80,5 @@ system_services = [
     "asusd",
 ]
 
-# System locale.
+# Default locale — matches CachyOS installer defaults for US English.
 system_locale = "en_US.UTF-8"

--- a/tasks/system.py
+++ b/tasks/system.py
@@ -16,14 +16,15 @@ Locale:
     Ensures /etc/locale.conf has the correct LANG= setting.
 """
 
-import os
+import getpass
 
 from pyinfra import host
 from pyinfra.operations import files, server, systemd
 
-# Resolved at runtime — pyinfra runs locally via @local, so $USER is always
-# the real invoking user (or testuser in CI).
-_current_user = os.environ["USER"]
+# Resolved at runtime — pyinfra runs locally via @local, so this is always
+# the real invoking user. getpass.getuser() reads from the passwd database,
+# which works even when $USER is unset (e.g., Docker RUN steps).
+_current_user = getpass.getuser()
 
 # ---------------------------------------------------------------------------
 # Groups

--- a/tasks/system.py
+++ b/tasks/system.py
@@ -24,7 +24,7 @@ from pyinfra.operations import files, server, systemd
 # Resolved at runtime — pyinfra runs locally via @local, so this is always
 # the real invoking user. getpass.getuser() reads from the passwd database,
 # which works even when $USER is unset (e.g., Docker RUN steps).
-_current_user = getpass.getuser()
+current_user = getpass.getuser()
 
 # ---------------------------------------------------------------------------
 # Groups
@@ -32,17 +32,17 @@ _current_user = getpass.getuser()
 # docker is package-managed but created explicitly as a safety net in case
 # include order changes. render/video are kernel-managed — no creation needed.
 
-for _group in host.data.system_groups:
+for group in host.data.system_groups:
     server.group(
-        name=f"Ensure {_group} group exists",
-        group=_group,
+        name=f"Ensure {group} group exists",
+        group=group,
         system=True,
         _sudo=True,
     )
 
 server.user(
-    name=f"Add {_current_user} to supplementary groups",
-    user=_current_user,
+    name=f"Add {current_user} to supplementary groups",
+    user=current_user,
     groups=host.data.user_groups,
     append=True,
     _sudo=True,
@@ -53,10 +53,10 @@ server.user(
 # ---------------------------------------------------------------------------
 # Runs after packages so the service unit files are already on disk.
 
-for _service in host.data.system_services:
+for service in host.data.system_services:
     systemd.service(
-        name=f"Enable and start {_service}",
-        service=_service,
+        name=f"Enable and start {service}",
+        service=service,
         running=True,
         enabled=True,
         _sudo=True,

--- a/tasks/system.py
+++ b/tasks/system.py
@@ -1,0 +1,76 @@
+"""System configuration tasks.
+
+Configures user group memberships, enables systemd services, and sets the
+system locale. All values come from group_data/all.py via host.data.
+
+Groups:
+    Creates system groups (e.g., docker) that may not exist yet, then adds
+    the current user to all configured supplementary groups. Groups like
+    render and video are kernel-managed and assumed to exist.
+
+Services:
+    Enables and starts systemd services installed by tasks/packages.py.
+    Runs after packages so the service units are already on disk.
+
+Locale:
+    Ensures /etc/locale.conf has the correct LANG= setting.
+"""
+
+import os
+
+from pyinfra import host
+from pyinfra.operations import files, server, systemd
+
+# Resolved at runtime — pyinfra runs locally via @local, so $USER is always
+# the real invoking user (or testuser in CI).
+_current_user = os.environ["USER"]
+
+# ---------------------------------------------------------------------------
+# Groups
+# ---------------------------------------------------------------------------
+# Ensure system groups exist before adding the user.
+# docker is package-managed but created explicitly as a safety net in case
+# include order changes. render/video are kernel-managed — no creation needed.
+
+for _group in host.data.system_groups:
+    server.group(
+        name=f"Ensure {_group} group exists",
+        group=_group,
+        system=True,
+        _sudo=True,
+    )
+
+server.user(
+    name=f"Add {_current_user} to supplementary groups",
+    user=_current_user,
+    groups=host.data.user_groups,
+    append=True,
+    _sudo=True,
+)
+
+# ---------------------------------------------------------------------------
+# Systemd services
+# ---------------------------------------------------------------------------
+# Enable and start services installed by tasks/packages.py.
+
+for _service in host.data.system_services:
+    systemd.service(
+        name=f"Enable and start {_service}",
+        service=_service,
+        running=True,
+        enabled=True,
+        _sudo=True,
+    )
+
+# ---------------------------------------------------------------------------
+# Locale
+# ---------------------------------------------------------------------------
+# Replace any existing LANG= line or append if missing.
+
+files.line(
+    name=f"Set system locale to {host.data.system_locale}",
+    path="/etc/locale.conf",
+    line="^LANG=",
+    replace=f"LANG={host.data.system_locale}",
+    _sudo=True,
+)

--- a/tasks/system.py
+++ b/tasks/system.py
@@ -29,7 +29,6 @@ _current_user = getpass.getuser()
 # ---------------------------------------------------------------------------
 # Groups
 # ---------------------------------------------------------------------------
-# Ensure system groups exist before adding the user.
 # docker is package-managed but created explicitly as a safety net in case
 # include order changes. render/video are kernel-managed — no creation needed.
 
@@ -52,7 +51,7 @@ server.user(
 # ---------------------------------------------------------------------------
 # Systemd services
 # ---------------------------------------------------------------------------
-# Enable and start services installed by tasks/packages.py.
+# Runs after packages so the service unit files are already on disk.
 
 for _service in host.data.system_services:
     systemd.service(
@@ -66,7 +65,8 @@ for _service in host.data.system_services:
 # ---------------------------------------------------------------------------
 # Locale
 # ---------------------------------------------------------------------------
-# Replace any existing LANG= line or append if missing.
+# Locale must be set explicitly — CachyOS images may ship with a different
+# default, and systemd reads LANG= from /etc/locale.conf at boot.
 
 files.line(
     name=f"Set system locale to {host.data.system_locale}",


### PR DESCRIPTION
### Related Issues

- fixes #222

### Proposed Changes:

Implements Phase 2 of the provisioner: `tasks/system.py` handles the three system-level concerns that must run after package installation.

**Group management** — creates system groups (e.g. `docker`) that may not exist yet, then adds the current user to all configured supplementary groups. Groups like `render` and `video` are kernel-managed and assumed to exist; only the groups we own need explicit creation.

**Service enablement** — iterates `system_services` from `group_data/all.py` and enables + starts each via `systemd.service`. Running this after `packages.py` guarantees unit files are already on disk.

**Locale** — writes `LANG=<locale>` to `/etc/locale.conf` via `files.line`. CachyOS container images may ship a different default; this makes it deterministic.

All configuration values live in `group_data/all.py` (`system_groups`, `user_groups`, `system_services`, `system_locale`). Task files contain no hardcoded values.

A notable implementation detail: `getpass.getuser()` is used instead of `os.environ["USER"]` because `$USER` is unset inside Docker `RUN` steps, which is the primary CI environment.

### Testing:

- Container test: `docker build -f tests/Containerfile -t hanzo:test .`

### Extra Notes (optional):

`deploy.py` uncomments the `local.include("tasks/system.py")` line that was already stubbed in as a placeholder from the initial scaffold.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`