### PR TITLE
feat(dotfiles): add dotfiles task for clone, installer, git config (#222)

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -43,7 +43,7 @@ local.include("tasks/packages.py")
 # Phase 2 tasks (uncomment as they land):
 local.include("tasks/system.py")
 # local.include("tasks/tools.py")
-# local.include("tasks/dotfiles.py")
+local.include("tasks/dotfiles.py")
 
 # ---------------------------------------------------------------------------
 # Hardware detection: include GZ302 fixes only on matching hardware.

--- a/group_data/all.py
+++ b/group_data/all.py
@@ -82,3 +82,6 @@ system_services = [
 
 # Default locale — matches CachyOS installer defaults for US English.
 system_locale = "en_US.UTF-8"
+
+dotfiles_repo = "https://github.com/palazzem/dotfiles.git"
+dotfiles_dir = "~/.dotfiles"

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -1,0 +1,77 @@
+"""Dotfiles setup task.
+
+Clones the user's dotfiles repository to the configured directory (or pulls
+if it already exists), runs the repository's installer script, and injects
+git identity (user.name, user.email) from the Hanzo configuration. Git
+identity injection is skipped with a warning when values are not configured.
+"""
+
+import os
+import shlex
+
+from pyinfra import host, logger
+from pyinfra.operations import server
+
+# ---------------------------------------------------------------------------
+# Resolve paths — expand ~ to the actual home directory at runtime
+# ---------------------------------------------------------------------------
+_dotfiles_dir = os.path.expanduser(host.data.dotfiles_dir)
+
+# ---------------------------------------------------------------------------
+# Clone or update the dotfiles repository
+# ---------------------------------------------------------------------------
+# Mirrors the clone-or-pull pattern from bootstrap.sh: check for .git to
+# decide between clone and pull. --ff-only prevents merge commits if the
+# local branch has diverged unexpectedly.
+if os.path.isdir(os.path.join(_dotfiles_dir, ".git")):
+    server.shell(
+        name="Pull latest dotfiles changes",
+        commands=[
+            f"git -C {shlex.quote(_dotfiles_dir)} pull --ff-only",
+        ],
+        _sudo=False,
+    )
+else:
+    server.shell(
+        name="Clone dotfiles repository",
+        commands=[
+            f"git clone {shlex.quote(host.data.dotfiles_repo)} {shlex.quote(_dotfiles_dir)}",
+        ],
+        _sudo=False,
+    )
+
+# ---------------------------------------------------------------------------
+# Run the dotfiles installer
+# ---------------------------------------------------------------------------
+# The installer (install.sh) is maintained in the dotfiles repo and handles
+# symlinking config files. It is designed to be idempotent (re-runnable).
+server.shell(
+    name="Run dotfiles installer",
+    commands=[os.path.join(_dotfiles_dir, "install.sh")],
+    _sudo=False,
+)
+
+# ---------------------------------------------------------------------------
+# Git identity injection
+# ---------------------------------------------------------------------------
+# deploy.py parses ~/.config/hanzo/config and sets host.data.hanzo_fullname
+# and host.data.hanzo_email. If the config file is missing or values are
+# empty, we warn and skip — a partial identity (name without email or
+# vice-versa) is invalid for git, so both must be present.
+_fullname = host.data.get("hanzo_fullname")
+_email = host.data.get("hanzo_email")
+
+if _fullname and _email:
+    server.shell(
+        name="Inject git identity from Hanzo config",
+        commands=[
+            f"git config --global user.name {shlex.quote(_fullname)}",
+            f"git config --global user.email {shlex.quote(_email)}",
+        ],
+        _sudo=False,
+    )
+else:
+    logger.warning(
+        "hanzo_fullname or hanzo_email not configured — skipping git identity injection. "
+        "Run bootstrap.sh or edit ~/.config/hanzo/config to set them."
+    )

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -47,7 +47,7 @@ else:
 # symlinking config files. It is designed to be idempotent (re-runnable).
 server.shell(
     name="Run dotfiles installer",
-    commands=[os.path.join(_dotfiles_dir, "install.sh")],
+    commands=[shlex.quote(os.path.join(_dotfiles_dir, "install.sh"))],
     _sudo=False,
 )
 

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -19,4 +19,13 @@ RUN uv tool install pyinfra
 
 # Validate pyinfra scripts with a dry run
 ENV SKIP_HARDWARE_CHECK=1
+
+# Exercises: clone branch (no .dotfiles), identity-skip branch (no config)
 RUN pyinfra -y @local deploy.py --dry
+
+# Exercises: pull branch (existing .dotfiles repo) and identity injection branch
+RUN mkdir -p /home/testuser/.dotfiles/.git && \
+    mkdir -p /home/testuser/.config/hanzo && \
+    printf 'HANZO_FULLNAME="Test User"\nHANZO_EMAIL="test@example.com"\n' \
+      > /home/testuser/.config/hanzo/config && \
+    pyinfra -y @local deploy.py --dry


### PR DESCRIPTION
### Related Issues

- fixes #222

### Proposed Changes:

Implements the dotfiles pyinfra task as part of Phase 2 provisioning.

**`group_data/all.py`** — adds `dotfiles_repo` and `dotfiles_dir` configuration keys so task files never hardcode paths or URLs.

**`tasks/dotfiles.py`** — new task file with three responsibilities:
- Clone the dotfiles repository on first run; pull with `--ff-only` on subsequent runs (detected via `.git` directory presence).
- Run the repo's `install.sh` installer, which handles symlinking config files idempotently.
- Inject `user.name` and `user.email` into global git config from the Hanzo user config (`~/.config/hanzo/config`). If either value is absent, the step is skipped with a warning rather than failing the run — a partial identity is invalid for git.

All operations use `_sudo=False` (user-space) and rely on `server.shell` as the correct escape hatch since no pyinfra built-in covers git clone/pull/config.

**`deploy.py`** — uncomments `local.include("tasks/dotfiles.py")` to activate the task in the deploy pipeline.

**`tests/Containerfile`** — adds two `pyinfra --dry` passes:
1. Clone branch: no `.dotfiles` present, no Hanzo config → exercises clone path and identity-skip warning.
2. Pull + identity branch: pre-created `.git` directory and a populated config file → exercises pull path and identity injection.

### Testing:

- Container dry-run covers both the clone and pull code paths, and both the identity-configured and identity-missing branches.
- Run locally with: `docker build -f tests/Containerfile -t hanzo:test .`

### Extra Notes (optional):

The `os.path.isdir` check for `.git` at module level (before any `server.shell` call) is intentional: pyinfra evaluates task files on the controller host to build the operation graph, so the check against the local filesystem is valid for `@local` deployments.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`