### PR TITLE
feat(dotfiles): clone claude-config repo into ~/.claude

### DIFF
--- a/group_data/all.py
+++ b/group_data/all.py
@@ -87,6 +87,9 @@ system_locale = "en_US.UTF-8"
 dotfiles_repo = "https://github.com/palazzem/dotfiles.git"
 dotfiles_dir = "~/.dotfiles"
 
+claude_config_repo = "https://github.com/palazzem/claude-config.git"
+claude_config_dir = "~/.claude"
+
 # ---------------------------------------------------------------------------
 # GZ302 (ASUS ROG Flow Z13) hardware configuration
 # ---------------------------------------------------------------------------

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -1,9 +1,14 @@
-"""Dotfiles setup task.
+"""Dotfiles and Claude Code configuration setup task.
 
 Clones the user's dotfiles repository to the configured directory (or pulls
 if it already exists), runs the repository's installer script, and injects
 git identity (user.name, user.email) from the Hanzo configuration. Git
 identity injection is skipped with a warning when values are not configured.
+
+Also clones the Claude Code configuration repository (claude-config) into
+~/.claude. If ~/.claude already exists but isn't a git repo (created by
+Claude Code on first use), the directory is adopted in-place as a git repo
+while preserving untracked runtime files.
 """
 
 import os
@@ -74,4 +79,49 @@ else:
     logger.warning(
         "hanzo_fullname or hanzo_email not configured — skipping git identity injection. "
         "Run bootstrap.sh or edit ~/.config/hanzo/config to set them."
+    )
+
+# ---------------------------------------------------------------------------
+# Clone or update the Claude Code configuration repository
+# ---------------------------------------------------------------------------
+# claude-config provides versioned Claude Code settings (CLAUDE.md, skills,
+# agents, settings.json). The repo uses an ignore-all .gitignore that
+# whitelists only config files, so untracked runtime files (memory/,
+# projects/, credentials) are preserved across all code paths.
+_claude_config_dir = os.path.expanduser(host.data.claude_config_dir)
+
+if os.path.isdir(os.path.join(_claude_config_dir, ".git")):
+    server.shell(
+        name="Pull latest claude-config changes",
+        commands=[
+            f"git -C {shlex.quote(_claude_config_dir)} pull --ff-only",
+        ],
+        _sudo=False,
+    )
+elif os.path.isdir(_claude_config_dir):
+    # Claude Code creates ~/.claude on first use. Adopt the existing
+    # directory as a git repo: init, fetch remote, and hard-reset to
+    # overwrite tracked files (repo is source of truth) while leaving
+    # untracked runtime files untouched.
+    server.shell(
+        name="Adopt existing ~/.claude directory as claude-config repo",
+        commands=[
+            f"git init {shlex.quote(_claude_config_dir)}",
+            f"git -C {shlex.quote(_claude_config_dir)} remote add origin"
+            f" {shlex.quote(host.data.claude_config_repo)}",
+            f"git -C {shlex.quote(_claude_config_dir)} fetch origin",
+            f"git -C {shlex.quote(_claude_config_dir)} reset --hard origin/main",
+            f"git -C {shlex.quote(_claude_config_dir)} branch -M main",
+            f"git -C {shlex.quote(_claude_config_dir)} branch --set-upstream-to=origin/main",
+        ],
+        _sudo=False,
+    )
+else:
+    server.shell(
+        name="Clone claude-config repository",
+        commands=[
+            f"git clone {shlex.quote(host.data.claude_config_repo)}"
+            f" {shlex.quote(_claude_config_dir)}",
+        ],
+        _sudo=False,
     )

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -107,7 +107,9 @@ elif os.path.isdir(_claude_config_dir):
         name="Adopt existing ~/.claude directory as claude-config repo",
         commands=[
             f"git init {shlex.quote(_claude_config_dir)}",
-            f"git -C {shlex.quote(_claude_config_dir)} remote add origin"
+            f"git -C {shlex.quote(_claude_config_dir)} remote set-url origin"
+            f" {shlex.quote(host.data.claude_config_repo)} 2>/dev/null"
+            f" || git -C {shlex.quote(_claude_config_dir)} remote add origin"
             f" {shlex.quote(host.data.claude_config_repo)}",
             f"git -C {shlex.quote(_claude_config_dir)} fetch origin",
             f"git -C {shlex.quote(_claude_config_dir)} reset --hard origin/main",

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -25,6 +25,7 @@ RUN pyinfra -y @local deploy.py --dry
 
 # Exercises: pull branch (existing .dotfiles repo) and identity injection branch
 RUN mkdir -p /home/testuser/.dotfiles/.git && \
+    mkdir -p /home/testuser/.claude/.git && \
     mkdir -p /home/testuser/.config/hanzo && \
     printf 'HANZO_FULLNAME="Test User"\nHANZO_EMAIL="test@example.com"\n' \
       > /home/testuser/.config/hanzo/config && \

--- a/tests/Containerfile
+++ b/tests/Containerfile
@@ -23,7 +23,8 @@ ENV SKIP_HARDWARE_CHECK=1
 # Exercises: clone branch (no .dotfiles), identity-skip branch (no config)
 RUN pyinfra -y @local deploy.py --dry
 
-# Exercises: pull branch (existing .dotfiles repo) and identity injection branch
+# Exercises: dotfiles pull branch (existing .dotfiles), identity injection,
+# and claude-config pull branch (existing .claude repo)
 RUN mkdir -p /home/testuser/.dotfiles/.git && \
     mkdir -p /home/testuser/.claude/.git && \
     mkdir -p /home/testuser/.config/hanzo && \


### PR DESCRIPTION
### Related Issues

- fixes #222

### Proposed Changes:

Adds automatic provisioning of the Claude Code configuration repository (`claude-config`) into `~/.claude` during the dotfiles setup phase.

**Problem:** Claude Code creates `~/.claude` on first use with runtime files (memory, projects, credentials). A plain `git clone` would fail if that directory already exists, causing the provisioner to error out on machines that have run Claude Code before.

**Solution — three-branch adopt logic in `tasks/dotfiles.py`:**

- **Fresh machine** (`~/.claude` absent): standard `git clone`.
- **Existing plain directory** (`~/.claude` exists, no `.git`): adopts it in-place — `git init`, adds the remote, fetches, and `reset --hard origin/main` to overwrite tracked config files while leaving untracked runtime files untouched. Each step is idempotent so a partial failure can be re-run safely.
- **Already a git repo** (`~/.claude/.git` present): `git pull --ff-only` to stay current.

The repo's `ignore-all` `.gitignore` (whitelist approach) ensures runtime files like `memory/`, `projects/`, and credentials are never at risk across all three paths.

**Data:** `claude_config_repo` and `claude_config_dir` are added to `group_data/all.py` following the single-source-of-truth rule — task files access them via `host.data.*`.

### Testing:

Container test exercises both the clone branch (no `~/.claude` present) and the pull branch (`.git` already exists) via `tests/Containerfile`. The adopt-in-place branch (directory exists, no `.git`) is covered by idempotency design — each git command is independently safe to re-run.

### Extra Notes (optional):

The adopt path uses `reset --hard` intentionally: the repo is the source of truth for tracked config files. Untracked runtime files (which Claude Code manages) are untouched by `reset --hard` because they are not in the index.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`