### PR TITLE
feat(system): enable ssh-agent as a systemd user service

### DIFF
--- a/group_data/all.py
+++ b/group_data/all.py
@@ -81,6 +81,11 @@ system_services = [
     "asusd",
 ]
 
+# Systemd user services to enable (systemctl --user).
+user_services = [
+    "ssh-agent",
+]
+
 # Default locale — matches CachyOS installer defaults for US English.
 system_locale = "en_US.UTF-8"
 

--- a/tasks/system.py
+++ b/tasks/system.py
@@ -67,8 +67,8 @@ for service in host.data.system_services:
 # ---------------------------------------------------------------------------
 # User services (systemd --user)
 # ---------------------------------------------------------------------------
-# Per-user services managed via systemctl --user. These run in the user's
-# session and do not require root.
+# Separated from system services because user-mode units need the invoking
+# user's systemd instance — _sudo=True would target root's session manager.
 
 for service in host.data.user_services:
     systemd.service(

--- a/tasks/system.py
+++ b/tasks/system.py
@@ -11,6 +11,8 @@ Groups:
 Services:
     Enables and starts systemd services installed by tasks/packages.py.
     Runs after packages so the service units are already on disk.
+    Also enables user-scoped services (systemctl --user) that run in
+    the user's session without root.
 
 Locale:
     Ensures /etc/locale.conf has the correct LANG= setting.
@@ -60,6 +62,22 @@ for service in host.data.system_services:
         running=True,
         enabled=True,
         _sudo=True,
+    )
+
+# ---------------------------------------------------------------------------
+# User services (systemd --user)
+# ---------------------------------------------------------------------------
+# Per-user services managed via systemctl --user. These run in the user's
+# session and do not require root.
+
+for service in host.data.user_services:
+    systemd.service(
+        name=f"Enable and start {service} (user)",
+        service=service,
+        running=True,
+        enabled=True,
+        user_mode=True,
+        _sudo=False,
     )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issues

- fixes #222

### Proposed Changes:

Adds support for systemd user-scoped services and uses it to enable `ssh-agent` at session start.

Two changes work together:

- **`group_data/all.py`**: Introduces a `user_services` list (initially containing `ssh-agent`) as the single source of truth for user-mode services. Follows the same data-in-`group_data`, logic-in-`tasks` convention used throughout the project.

- **`tasks/system.py`**: Adds a dedicated loop that iterates over `host.data.user_services` and calls `systemd.service(..., user_mode=True, _sudo=False)`. User-mode units are handled separately from system services because they must target the invoking user's systemd instance — using `_sudo=True` would incorrectly target root's session manager.

### Testing:

- Container test: `docker build -f tests/Containerfile -t hanzo:test .`
- Verify `ssh-agent` is active after provisioning: `systemctl --user status ssh-agent`

### Extra Notes (optional):

The `user_mode=True` flag on `systemd.service` is the key detail. Without it, pyinfra would call `systemctl` as root, missing the per-user session manager that owns user-scoped units.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`