### PR TITLE
docs: improve README.md and CLAUDE.md documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,6 @@ docker build -f tests/Containerfile -t hanzo:test .
 - Use `$(...)` for command substitution, never backticks.
 - Quote all variable expansions: `"$VAR"`, not `$VAR`.
 - Interactive prompts must read from `/dev/tty` for `curl | bash` compatibility.
-- Exception: systemd hooks that must run best-effort (e.g., suspend hooks) may omit `set -euo pipefail` with a comment explaining why.
 
 ### Python
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ docker build -f tests/Containerfile -t hanzo:test .
 - `_sudo=True` for system operations (package installs, service management, config writes).
 - `_sudo=False` for user-space operations (paru, pyenv, dotfiles).
 - Use `tasks/packages.py` as the reference implementation.
+- Use `shlex.quote()` for any interpolated values in `server.shell` commands.
 
 ### Shell Scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,12 @@ docker build -f tests/Containerfile -t hanzo:test .
 | `pre-commit run --all-files` | Lint all files |
 | `docker build -f tests/Containerfile -t hanzo:test .` | Build and test in CachyOS container |
 
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SKIP_HARDWARE_CHECK` | Set to `1` to bypass DMI-based hardware detection in `deploy.py`. Used in CI (see `tests/Containerfile`) where `/sys/class/dmi/id/product_name` is unavailable. |
+
 ## Task Completion Checklist
 
 Before submitting changes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ docker build -f tests/Containerfile -t hanzo:test .
 - Use `$(...)` for command substitution, never backticks.
 - Quote all variable expansions: `"$VAR"`, not `$VAR`.
 - Interactive prompts must read from `/dev/tty` for `curl | bash` compatibility.
+- Exception: systemd hooks that must run best-effort (e.g., suspend hooks) may omit `set -euo pipefail` with a comment explaining why.
 
 ### Python
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ Hanzo uses pyinfra to run operations locally via `pyinfra @local`. All operation
 - `tasks/` — individual task files (packages, system, tools, dotfiles, hardware)
 - `templates/` — Jinja2 templates for config files
 
+## Development
+
+Clone the repository and install the pre-commit hooks:
+
+```bash
+git clone https://github.com/palazzem/hanzo.git
+cd hanzo
+pre-commit install
+```
+
+Run linters locally:
+
+```bash
+pre-commit run --all-files
+```
+
+Run the full test suite inside a CachyOS container:
+
+```bash
+docker build -f tests/Containerfile -t hanzo:test .
+```
+
 ## Contribute
 
 This tool provisions my personal CachyOS setup. You may use this repository as a base to create your own configuration. I'll be glad to accept any PR that:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hanzo
 
+[![Testing](https://github.com/palazzem/hanzo/actions/workflows/test.yaml/badge.svg)](https://github.com/palazzem/hanzo/actions/workflows/test.yaml)
+
 > Hattori Hanzō: You must have big rats if you need Hattori Hanzo's steel.
 > The Bride: ...Huge.
 

--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ I will not merge pull requests that add new development tools, but I will be gra
 in the [issue tracker](https://github.com/palazzem/hanzo/issues).
 
 See `CLAUDE.md` for the task authoring contract.
+
+## License
+
+BSD 2-Clause. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
### Related Issues

- fixes #233

### Proposed Changes:

Improves documentation across `README.md` and `CLAUDE.md`:

**README.md:**
- Add CI status badge linking to the Testing workflow
- Add Development section with clone, pre-commit, lint, and container test instructions
- Add License section (BSD 2-Clause)

**CLAUDE.md:**
- Add `shlex.quote()` guideline for `server.shell` command interpolation
- Document `SKIP_HARDWARE_CHECK` environment variable in a new Environment Variables section
- Add shell script exception for best-effort systemd hooks that may omit `set -euo pipefail`

### Testing:

- `pre-commit run --all-files` passes
- `docker build -f tests/Containerfile -t hanzo:test .` succeeds
- Documentation-only changes; no functional code modified

### Extra Notes (optional):

All additions codify existing practices already present in the codebase (e.g., `shlex.quote()` usage in `tasks/dotfiles.py`, `SKIP_HARDWARE_CHECK` in `deploy.py` and `tests/Containerfile`, best-effort hook pattern in `templates/gz302-suspend.sh.j2`).

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`