### PR TITLE
fix(templates): replace hardcoded values with Jinja2 expressions

### DIFF
--- a/group_data/all.py
+++ b/group_data/all.py
@@ -102,6 +102,20 @@ claude_config_dir = "~/.claude"
 # artifacts and flicker on the Strix Halo OLED panel (kernel 7.0+).
 gz302_oled_kernel_param = "amdgpu.dcdebugmask=0x600"
 
+# GPU modprobe options for Radeon 8060S (RDNA 3.5, Strix Halo).
+# All power features except GFXOFF (bit 15) which causes GPU hangs.
+gz302_amdgpu_ppfeaturemask = "0xffff7fff"
+# Disable Adaptive Backlight Management (not applicable to OLED panels).
+gz302_amdgpu_abmlevel = 0
+# Disable scatter-gather display to prevent OLED flicker under memory pressure.
+gz302_amdgpu_sg_display = 0
+# Disable Compute Wavefront Save-Restore to prevent GPU hangs on RDNA 3.5.
+gz302_amdgpu_cwsr_enable = 0
+
+# HID modprobe option for ASUS keyboard.
+# F-row defaults to media keys; press Fn for standard F1-F12.
+gz302_hid_fnlock_default = 0
+
 # ASUS USB identifiers for keyboard, touchpad, and lightbar devices.
 # Used by suspend hook (USB reset, HID unbind), hwdb (key remap), and
 # udev rule (RGB).

--- a/templates/amdgpu.conf.j2
+++ b/templates/amdgpu.conf.j2
@@ -1,21 +1,21 @@
 # AMD GPU configuration for Radeon 8060S (RDNA 3.5, Strix Halo)
 # Managed by Hanzo. Do not edit manually.
 
-# 0xffff7fff: all power feature bits enabled except bit 15 (GFXOFF).
+# {{ data.gz302_amdgpu_ppfeaturemask }}: all power feature bits enabled except bit 15 (GFXOFF).
 # GFXOFF causes GPU hangs under rapid power-state transitions on the
 # Strix Halo iGPU.
-options amdgpu ppfeaturemask=0xffff7fff
+options amdgpu ppfeaturemask={{ data.gz302_amdgpu_ppfeaturemask }}
 
 # Disable Adaptive Backlight Management. Not applicable to OLED panels
 # (driver skips ABM when DPCD reports oled=1), but explicit disable is
 # belt-and-suspenders.
-options amdgpu abmlevel=0
+options amdgpu abmlevel={{ data.gz302_amdgpu_abmlevel }}
 
 # Disable scatter-gather display on this APU. Prevents OLED flicker
 # under memory pressure.
-options amdgpu sg_display=0
+options amdgpu sg_display={{ data.gz302_amdgpu_sg_display }}
 
 # Disable Compute Wavefront Save-Restore. Prevents GPU hangs and
 # graphical artifacts caused by register file synchronization issues
 # on RDNA 3.5.
-options amdgpu cwsr_enable=0
+options amdgpu cwsr_enable={{ data.gz302_amdgpu_cwsr_enable }}

--- a/templates/hid_asus.conf.j2
+++ b/templates/hid_asus.conf.j2
@@ -1,6 +1,6 @@
 # ASUS HID configuration for GZ302
 # Managed by Hanzo. Do not edit manually.
 
-# fnlock_default=0: F1-F12 keys act as media/function keys by default.
+# fnlock_default={{ data.gz302_hid_fnlock_default }}: F1-F12 keys act as media/function keys by default.
 # Press Fn to get standard F1-F12 behavior.
-options hid_asus fnlock_default=0
+options hid_asus fnlock_default={{ data.gz302_hid_fnlock_default }}


### PR DESCRIPTION
### Related Issues

- fixes #232

### Proposed Changes:

The `amdgpu.conf.j2` and `hid_asus.conf.j2` templates were using `.j2` extensions but contained no Jinja2 expressions — all values were hardcoded literals. This violated the project's single-source-of-truth rule: the same values were duplicated between the templates and `group_data/all.py`, creating a maintenance hazard where changing a value in one place would silently leave the other stale.

This PR:
- Adds five new variables to `group_data/all.py` for GZ302 GPU (`gz302_amdgpu_ppfeaturemask`, `gz302_amdgpu_abmlevel`, `gz302_amdgpu_sg_display`, `gz302_amdgpu_cwsr_enable`) and HID (`gz302_hid_fnlock_default`) modprobe options.
- Replaces all hardcoded values in `amdgpu.conf.j2` and `hid_asus.conf.j2` with `{{ data.<variable> }}` expressions so the templates actually use the Jinja2 rendering pipeline.

### Testing:

- Container build: `docker build -f tests/Containerfile -t hanzo:test .`
- Rendered output is functionally identical to the previous hardcoded templates; only the source of truth changes.

### Extra Notes (optional):

Inline comments in the templates that included the literal value (e.g. `# 0xffff7fff: all power...`) have been updated to use the Jinja2 expression as well, so they stay in sync automatically.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`