### PR TITLE
fix(tasks): shell-quote interpolated values and DRY up pull logic

### DIFF
--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -26,8 +26,8 @@ _dotfiles_dir = os.path.expanduser(host.data.dotfiles_dir)
 # Clone or update the dotfiles repository
 # ---------------------------------------------------------------------------
 # Mirrors the clone-or-pull pattern from bootstrap.sh: check for .git to
-# decide between clone and pull. --ff-only prevents merge commits if the
-# local branch has diverged unexpectedly.
+# decide between clone and pull. os.path.isdir() evaluates at control time
+# (Python parse), not deploy time — safe because Hanzo always targets @local.
 if os.path.isdir(os.path.join(_dotfiles_dir, ".git")):
     server.shell(
         name="Pull latest dotfiles changes",
@@ -88,6 +88,7 @@ else:
 # agents, settings.json). The repo uses an ignore-all .gitignore that
 # whitelists only config files, so untracked runtime files (memory/,
 # projects/, credentials) are preserved across all code paths.
+# Expanded on the control machine — safe because Hanzo always targets @local.
 _claude_config_dir = os.path.expanduser(host.data.claude_config_dir)
 
 if os.path.isdir(os.path.join(_claude_config_dir, ".git")):

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -17,19 +17,7 @@ import shlex
 from pyinfra import host, logger
 from pyinfra.operations import server
 
-
-def _git_pull_ff_cmd(repo_dir: str) -> str:
-    """Build a git pull --ff-only command with a graceful fallback on divergence.
-
-    Uses --ff-only to avoid accidental merge commits. On failure (diverged
-    branch, network error, etc.) warns and continues rather than aborting the
-    entire provisioning run — a stale checkout is acceptable; a failed
-    provision is not.
-    """
-    return (
-        f"git -C {shlex.quote(repo_dir)} pull --ff-only"
-        " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull' >&2"
-    )
+from tasks.helpers import shell_git_pull
 
 
 # ---------------------------------------------------------------------------
@@ -43,11 +31,11 @@ _dotfiles_dir = os.path.expanduser(host.data.dotfiles_dir)
 # Mirrors the clone-or-pull pattern from bootstrap.sh: check for .git to
 # decide between clone and pull. os.path.isdir() evaluates at control time
 # (Python parse), not deploy time — safe because Hanzo always targets @local.
-# Pull uses --ff-only with a graceful fallback (see _git_pull_ff_cmd).
+# Pull uses --ff-only with a graceful fallback (see helpers.shell_git_pull).
 if os.path.isdir(os.path.join(_dotfiles_dir, ".git")):
     server.shell(
         name="Pull latest dotfiles changes",
-        commands=[_git_pull_ff_cmd(_dotfiles_dir)],
+        commands=[shell_git_pull(_dotfiles_dir)],
         _sudo=False,
     )
 else:
@@ -108,7 +96,7 @@ _claude_config_dir = os.path.expanduser(host.data.claude_config_dir)
 if os.path.isdir(os.path.join(_claude_config_dir, ".git")):
     server.shell(
         name="Pull latest claude-config changes",
-        commands=[_git_pull_ff_cmd(_claude_config_dir)],
+        commands=[shell_git_pull(_claude_config_dir)],
         _sudo=False,
     )
 elif os.path.isdir(_claude_config_dir):

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -32,7 +32,8 @@ if os.path.isdir(os.path.join(_dotfiles_dir, ".git")):
     server.shell(
         name="Pull latest dotfiles changes",
         commands=[
-            f"git -C {shlex.quote(_dotfiles_dir)} pull --ff-only",
+            f"git -C {shlex.quote(_dotfiles_dir)} pull --ff-only"
+            " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull'",
         ],
         _sudo=False,
     )
@@ -95,7 +96,8 @@ if os.path.isdir(os.path.join(_claude_config_dir, ".git")):
     server.shell(
         name="Pull latest claude-config changes",
         commands=[
-            f"git -C {shlex.quote(_claude_config_dir)} pull --ff-only",
+            f"git -C {shlex.quote(_claude_config_dir)} pull --ff-only"
+            " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull'",
         ],
         _sudo=False,
     )

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -17,6 +17,21 @@ import shlex
 from pyinfra import host, logger
 from pyinfra.operations import server
 
+
+def _git_pull_ff_cmd(repo_dir: str) -> str:
+    """Build a git pull --ff-only command with a graceful fallback on divergence.
+
+    Uses --ff-only to avoid accidental merge commits. On failure (diverged
+    branch, network error, etc.) warns and continues rather than aborting the
+    entire provisioning run — a stale checkout is acceptable; a failed
+    provision is not.
+    """
+    return (
+        f"git -C {shlex.quote(repo_dir)} pull --ff-only"
+        " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull'"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Resolve paths — expand ~ to the actual home directory at runtime
 # ---------------------------------------------------------------------------
@@ -28,13 +43,11 @@ _dotfiles_dir = os.path.expanduser(host.data.dotfiles_dir)
 # Mirrors the clone-or-pull pattern from bootstrap.sh: check for .git to
 # decide between clone and pull. os.path.isdir() evaluates at control time
 # (Python parse), not deploy time — safe because Hanzo always targets @local.
+# Pull uses --ff-only with a graceful fallback (see _git_pull_ff_cmd).
 if os.path.isdir(os.path.join(_dotfiles_dir, ".git")):
     server.shell(
         name="Pull latest dotfiles changes",
-        commands=[
-            f"git -C {shlex.quote(_dotfiles_dir)} pull --ff-only"
-            " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull'",
-        ],
+        commands=[_git_pull_ff_cmd(_dotfiles_dir)],
         _sudo=False,
     )
 else:
@@ -95,10 +108,7 @@ _claude_config_dir = os.path.expanduser(host.data.claude_config_dir)
 if os.path.isdir(os.path.join(_claude_config_dir, ".git")):
     server.shell(
         name="Pull latest claude-config changes",
-        commands=[
-            f"git -C {shlex.quote(_claude_config_dir)} pull --ff-only"
-            " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull'",
-        ],
+        commands=[_git_pull_ff_cmd(_claude_config_dir)],
         _sudo=False,
     )
 elif os.path.isdir(_claude_config_dir):

--- a/tasks/dotfiles.py
+++ b/tasks/dotfiles.py
@@ -28,7 +28,7 @@ def _git_pull_ff_cmd(repo_dir: str) -> str:
     """
     return (
         f"git -C {shlex.quote(repo_dir)} pull --ff-only"
-        " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull'"
+        " || echo 'WARNING: fast-forward failed; local branch may have diverged — skipping pull' >&2"
     )
 
 

--- a/tasks/helpers.py
+++ b/tasks/helpers.py
@@ -1,0 +1,94 @@
+"""Shell command builders for pyinfra server.shell operations.
+
+Centralizes shell command construction so that every server.shell call
+across task files uses consistently quoted, well-tested patterns. Each
+function returns a shell command string ready to pass as an element in a
+server.shell(commands=[...]) list.
+
+All user-supplied values are quoted via shlex.quote() to prevent shell
+injection from unexpected characters in configuration data.
+"""
+
+import shlex
+
+# Each server.shell spawns a fresh shell where fnm-managed Node.js is
+# not on PATH. This preamble must prefix every command that needs
+# node/npm.
+FNM_ACTIVATE = 'eval "$(fnm env)"'
+
+
+def shell_git_pull(repo_dir: str) -> str:
+    """Build a git pull --ff-only command with a graceful fallback.
+
+    Uses --ff-only to avoid accidental merge commits. On failure (diverged
+    branch, network error, etc.) warns on stderr and continues rather than
+    aborting the entire provisioning run — a stale checkout is acceptable;
+    a failed provision is not.
+
+    Args:
+        repo_dir: Absolute path to the git repository.
+
+    Returns:
+        Shell command string.
+    """
+    return (
+        f"git -C {shlex.quote(repo_dir)} pull --ff-only"
+        " || echo 'WARNING: fast-forward failed; local branch may have"
+        " diverged — skipping pull' >&2"
+    )
+
+
+def shell_paru_install(packages: list[str]) -> str:
+    """Build an idempotent paru install command for AUR packages.
+
+    Uses --needed to skip already-installed packages and --noconfirm
+    for unattended execution. Each package name is individually quoted.
+
+    Args:
+        packages: List of AUR package names.
+
+    Returns:
+        Shell command string.
+    """
+    return "paru -S --needed --noconfirm " + " ".join(
+        shlex.quote(p) for p in packages
+    )
+
+
+def shell_uv_tool_install(tool: str) -> str:
+    """Build a check-then-install command for a uv tool.
+
+    Checks uv tool list output before installing to avoid errors on
+    already-installed tools. The grep anchors on "^tool " to prevent
+    substring false positives.
+
+    Args:
+        tool: Name of the uv tool to install.
+
+    Returns:
+        Shell command string.
+    """
+    return (
+        f'uv tool list 2>/dev/null | grep -q "^{tool} "'
+        f" || uv tool install {shlex.quote(tool)}"
+    )
+
+
+def shell_npm_install(pkg: str) -> str:
+    """Build a check-then-install command for a global npm package.
+
+    Activates fnm to make node/npm available in the fresh shell, then
+    checks npm list -g before installing to avoid reinstalling existing
+    packages.
+
+    Args:
+        pkg: npm package name (e.g., "@anthropic-ai/claude-code").
+
+    Returns:
+        Shell command string.
+    """
+    return (
+        f"{FNM_ACTIVATE} && "
+        f"(npm list -g {shlex.quote(pkg)} >/dev/null 2>&1"
+        f" || npm install -g {shlex.quote(pkg)})"
+    )

--- a/tasks/helpers.py
+++ b/tasks/helpers.py
@@ -50,9 +50,7 @@ def shell_paru_install(packages: list[str]) -> str:
     Returns:
         Shell command string.
     """
-    return "paru -S --needed --noconfirm " + " ".join(
-        shlex.quote(p) for p in packages
-    )
+    return "paru -S --needed --noconfirm " + " ".join(shlex.quote(p) for p in packages)
 
 
 def shell_uv_tool_install(tool: str) -> str:

--- a/tasks/packages.py
+++ b/tasks/packages.py
@@ -5,10 +5,10 @@ This is the reference implementation for how Hanzo tasks should be written —
 see CLAUDE.md for the full contract.
 """
 
-import shlex
-
 from pyinfra import host
 from pyinfra.operations import pacman, server
+
+from tasks.helpers import shell_paru_install
 
 # ---------------------------------------------------------------------------
 # Official repo packages (pacman)
@@ -50,9 +50,6 @@ pacman.packages(
 
 server.shell(
     name="Install AUR packages via paru",
-    commands=[
-        "paru -S --needed --noconfirm "
-        + " ".join(shlex.quote(p) for p in host.data.aur_packages),
-    ],
+    commands=[shell_paru_install(host.data.aur_packages)],
     _sudo=False,
 )

--- a/tasks/packages.py
+++ b/tasks/packages.py
@@ -5,6 +5,8 @@ This is the reference implementation for how Hanzo tasks should be written —
 see CLAUDE.md for the full contract.
 """
 
+import shlex
+
 from pyinfra import host
 from pyinfra.operations import pacman, server
 
@@ -49,7 +51,8 @@ pacman.packages(
 server.shell(
     name="Install AUR packages via paru",
     commands=[
-        "paru -S --needed --noconfirm " + " ".join(host.data.aur_packages),
+        "paru -S --needed --noconfirm "
+        + " ".join(shlex.quote(p) for p in host.data.aur_packages),
     ],
     _sudo=False,
 )

--- a/tasks/tools.py
+++ b/tasks/tools.py
@@ -11,14 +11,16 @@ Prerequisites:
 """
 
 import os
-import shlex
 
 from pyinfra import host
 from pyinfra.operations import files, server
 
-# Each server.shell spawns a fresh shell where fnm-managed Node.js is not
-# on PATH. This preamble must appear in every command that needs node/npm.
-_FNM_ACTIVATE = 'eval "$(fnm env)"'
+from tasks.helpers import (
+    FNM_ACTIVATE,
+    shell_npm_install,
+    shell_paru_install,
+    shell_uv_tool_install,
+)
 
 # ---------------------------------------------------------------------------
 # Version managers
@@ -52,7 +54,7 @@ server.shell(
 server.shell(
     name="Install Node.js LTS via fnm",
     commands=[
-        f'{_FNM_ACTIVATE} && fnm install --lts && fnm default "$(fnm current)"',
+        f'{FNM_ACTIVATE} && fnm install --lts && fnm default "$(fnm current)"',
     ],
     _sudo=False,
 )
@@ -86,9 +88,7 @@ files.directory(
 for _tool in host.data.uv_tools:
     server.shell(
         name=f"Install {_tool} via uv tool",
-        commands=[
-            f'uv tool list 2>/dev/null | grep -q "^{_tool} " || uv tool install {shlex.quote(_tool)}',
-        ],
+        commands=[shell_uv_tool_install(_tool)],
         _sudo=False,
     )
 
@@ -100,10 +100,7 @@ for _tool in host.data.uv_tools:
 # already-installed packages (same pattern as packages.py's paru call).
 server.shell(
     name="Install infrastructure AUR packages via paru",
-    commands=[
-        "paru -S --needed --noconfirm "
-        + " ".join(shlex.quote(p) for p in host.data.infra_aur_packages),
-    ],
+    commands=[shell_paru_install(host.data.infra_aur_packages)],
     _sudo=False,
 )
 
@@ -129,9 +126,6 @@ server.shell(
 for _pkg in host.data.npm_global_packages:
     server.shell(
         name=f"Install {_pkg} via npm",
-        commands=[
-            f"{_FNM_ACTIVATE} && "
-            f"(npm list -g {shlex.quote(_pkg)} >/dev/null 2>&1 || npm install -g {shlex.quote(_pkg)})",
-        ],
+        commands=[shell_npm_install(_pkg)],
         _sudo=False,
     )

--- a/tasks/tools.py
+++ b/tasks/tools.py
@@ -11,6 +11,7 @@ Prerequisites:
 """
 
 import os
+import shlex
 
 from pyinfra import host
 from pyinfra.operations import files, server
@@ -86,7 +87,7 @@ for _tool in host.data.uv_tools:
     server.shell(
         name=f"Install {_tool} via uv tool",
         commands=[
-            f'uv tool list 2>/dev/null | grep -q "^{_tool} " || uv tool install {_tool}',
+            f'uv tool list 2>/dev/null | grep -q "^{_tool} " || uv tool install {shlex.quote(_tool)}',
         ],
         _sudo=False,
     )
@@ -100,7 +101,8 @@ for _tool in host.data.uv_tools:
 server.shell(
     name="Install infrastructure AUR packages via paru",
     commands=[
-        "paru -S --needed --noconfirm " + " ".join(host.data.infra_aur_packages),
+        "paru -S --needed --noconfirm "
+        + " ".join(shlex.quote(p) for p in host.data.infra_aur_packages),
     ],
     _sudo=False,
 )
@@ -129,7 +131,7 @@ for _pkg in host.data.npm_global_packages:
         name=f"Install {_pkg} via npm",
         commands=[
             f"{_FNM_ACTIVATE} && "
-            f"(npm list -g {_pkg} >/dev/null 2>&1 || npm install -g {_pkg})",
+            f"(npm list -g {shlex.quote(_pkg)} >/dev/null 2>&1 || npm install -g {shlex.quote(_pkg)})",
         ],
         _sudo=False,
     )


### PR DESCRIPTION
### Related Issues

- fixes #234

### Proposed Changes:

Three related code quality fixes across the task layer:

**Shell injection hardening (`packages.py`, `tools.py`):** `shlex.quote()` is now applied to every package name before it is interpolated into a shell command string (`paru -S`, `uv tool install`, `npm install -g`). Without quoting, a package name containing shell metacharacters could silently corrupt the command or, in adversarial scenarios, execute unintended shell code. Values come from `group_data/all.py` which is under version control, so the practical risk is low today — but the fix removes an entire class of latent bug and makes the intent explicit.

**Graceful pull fallback (`dotfiles.py`):** The `git pull --ff-only` commands for both dotfiles and claude-config repos previously caused the entire provisioning run to abort if the local branch had diverged (e.g. after a manual commit or rebase). The new behaviour warns and continues — a stale checkout is acceptable; a failed provision is not.

**DRY helper (`dotfiles.py`):** The identical clone-or-pull pattern was duplicated for both repos. `_git_pull_ff_cmd()` extracts the command construction into a single place so the fallback logic only needs to change once.

### Testing:

- Existing behaviour is preserved for the happy path (fast-forward succeeds).
- The fallback path (diverged branch) now emits a `WARNING:` line instead of a non-zero exit.
- `shlex.quote()` is stdlib and has no observable runtime difference for well-formed package names.
- Manual verification: `pre-commit run --all-files` passes; container build passes.

### Extra Notes (optional):

The `os.path.isdir()` calls in `dotfiles.py` evaluate at Python parse time (control machine), not deploy time. This is safe because Hanzo always targets `@local`. The commits add comments documenting this assumption explicitly so future readers don't confuse it with a deploy-time check.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`