### PR TITLE
feat(lint): add ruff and shellcheck to pre-commit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,11 +27,6 @@ jobs:
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
 
-      - name: Validate shell scripts
-        run: |
-          bash -n bin/bootstrap.sh
-          bash -n bin/hanzo
-
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,9 @@ repos:
           - id: end-of-file-fixer
           - id: mixed-line-ending
           - id: trailing-whitespace
+
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.15.12
+      hooks:
+          - id: ruff-check
+          - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
       hooks:
           - id: ruff-check
           - id: ruff-format
+
+    - repo: https://github.com/shellcheck-py/shellcheck-py
+      rev: v0.11.0.1
+      hooks:
+          - id: shellcheck

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -10,7 +10,6 @@ set -euo pipefail
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
-RED='\033[0;31m'
 NC='\033[0m'
 
 log_info()    { echo -e "${GREEN}[hanzo]${NC} $1"; }


### PR DESCRIPTION
### Related Issues

- Closes #235

### Proposed Changes:

Adds two new hooks to `.pre-commit-config.yaml`:

- **ruff** (`ruff-check` + `ruff-format`): enforces Python linting and formatting via [astral-sh/ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) (v0.15.12). This replaces ad-hoc Python style checks with a fast, unified tool.
- **shellcheck** ([shellcheck-py](https://github.com/shellcheck-py/shellcheck-py) v0.11.0.1): statically analyses shell scripts for correctness. Because shellcheck performs a superset of what `bash -n` provides, the redundant "Validate shell scripts" CI step (which only ran `bash -n`) has been removed from `.github/workflows/test.yaml`.

As a side-effect, shellcheck flagged the unused `RED` colour variable in `bin/bootstrap.sh`, which has been removed.

### Testing:

Pre-commit hooks run automatically in the `lint` CI job via `pre-commit run --all-files`. Both tools now execute on every push and pull-request.

### Extra Notes (optional):

The `bash -n` CI step removal is intentional and non-regressive — shellcheck performs full static analysis including syntax checking, making the old step redundant.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`