### PR TITLE
feat(packages): add claude-desktop-bin and wifiman-desktop AUR packages

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -44,7 +44,9 @@ gaming_packages:
   - ffmpeg
 
 aur_packages:
+  - claude-desktop-bin
   - fnm-bin
+  - wifiman-desktop
 
 # ---------------------------------------------------------------------------
 # System configuration (roles/system)


### PR DESCRIPTION
### Related Issues

No corresponding GitHub issue.

### Proposed Changes

Adds two AUR packages to the `aur_packages` list in `group_vars/all.yml`, alphabetically sorted alongside the pre-existing `fnm-bin`:

- **`claude-desktop-bin`** — Claude Desktop GUI client. Chosen over `-native`, `-appimage`, and `-hardened-bin` variants for its highest AUR popularity (5.21) and vote count (14), plus recent maintainer activity (`patrickjaja`, last modified 2026-05-07). It ships Claude 1.6608 vs. the slightly newer 1.7196 in `-appimage`, but avoids the AppImage indirection layer and benefits from wider community testing.

- **`wifiman-desktop`** — Ubiquiti's official Wifiman network management app (maintainer `yochananmarqos`, last modified 2026-04-05). Not to be confused with the unrelated `wifiman` AUR package (a wpa_supplicant manager marked out-of-date since 2025-09).

No new roles, tasks, or variables were needed. The existing `kewlfft.aur.aur` task in `roles/packages/tasks/main.yml` already batches the full `aur_packages` list through paru with `become: false`.

### Testing

- `pre-commit run --all-files` passes (yamllint, ansible-lint, generic hooks).
- `docker build -f tests/Containerfile -t hanzo:test .` completes successfully — confirms the playbook loads and the "Install AUR packages" task is reached without error, with diff output showing all three packages. Note: `kewlfft.aur.aur` in `--check` mode does not perform full AUR dependency resolution.

### Extra Notes (optional)

The `aur_packages` list remains alphabetically sorted. If a different sort order convention is preferred, happy to adjust.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`