### PR TITLE
feat(packages): add Signal Desktop and Zoom under comm_packages

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -43,10 +43,16 @@ gaming_packages:
   - cachyos-gaming-applications
   - ffmpeg
 
+comm_packages:
+  - signal-desktop
+
 aur_packages:
   - claude-desktop-bin
   - fnm-bin
   - wifiman-desktop
+
+comm_aur_packages:
+  - zoom
 
 # ---------------------------------------------------------------------------
 # System configuration (roles/system)

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -42,10 +42,21 @@
     name: "{{ gaming_packages }}"
   become: true
 
+- name: Install communication packages
+  community.general.pacman:
+    name: "{{ comm_packages }}"
+  become: true
+
 # kewlfft.aur.aur accepts a list under `name:`, batching the underlying
 # paru invocation. Avoids per-iteration paru startup + AUR DB read cost.
 - name: Install AUR packages
   kewlfft.aur.aur:
     name: "{{ aur_packages }}"
+    use: paru
+  become: false
+
+- name: Install communication AUR packages
+  kewlfft.aur.aur:
+    name: "{{ comm_aur_packages }}"
     use: paru
   become: false


### PR DESCRIPTION
### Related Issues

N/A

### Proposed Changes

Introduces a `comm` (communication) package group following the `<theme>_packages` / `<theme>_aur_packages` naming convention:

- **`comm_packages`** — pacman packages installed via `community.general.pacman`:
  - `signal-desktop` (extra repository)
- **`comm_aur_packages`** — AUR packages installed via `kewlfft.aur.aur` + paru:
  - `zoom`

Two new tasks are added to `roles/packages/tasks/main.yml`:
- `Install communication packages` (`become: true`, pacman)
- `Install communication AUR packages` (`become: false`, paru)

#### Naming convention formalised

This PR formalises the `<theme>_packages` / `<theme>_aur_packages` pattern as the standard way to group packages by domain. The convention was already implied by the existing `infra_aur_packages` variable; this change makes it explicit and consistent. The global `aur_packages` list remains the catch-all for packages that don't belong to a specific theme.

### Testing

Container test passed in `--check --diff` mode:

```
docker build -f tests/Containerfile -t hanzo:test .
```

Both new tasks (`Install communication packages` and `Install communication AUR packages`) ran without error inside the CachyOS container.

### Extra Notes (optional)

The `signal-desktop` package is available in the extra repository and does not require AUR. `zoom` has no official Arch package and is sourced from AUR via paru, hence its placement in `comm_aur_packages`.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`