### PR TITLE
feat(packages): add 1Password, 1Password CLI, and ProtonVPN

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -86,6 +86,11 @@ security_aur_packages:
 # user's GPG keyring.
 onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
 
+# Keyserver used to fetch the AgileBits PGP key. keyserver.ubuntu.com is
+# the project's chosen mirror — more reliable than keys.openpgp.org for
+# AUR build flows. Swappable here without editing role logic.
+onepassword_gpg_keyserver: "hkps://keyserver.ubuntu.com"
+
 # ---------------------------------------------------------------------------
 # System configuration (roles/system)
 # ---------------------------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -70,6 +70,22 @@ virtualization_packages:
   - virt-viewer
   - virtiofsd
 
+# Security & secrets (AUR). 1password and 1password-cli are signed by
+# AgileBits — see onepassword_gpg_key below. proton-vpn-gtk-app is the
+# official Proton AG GTK client (replaces the legacy protonvpn-gui /
+# python-proton-client). paru resolves its many python-proton-* AUR
+# dependencies recursively.
+security_aur_packages:
+  - 1password
+  - 1password-cli
+  - proton-vpn-gtk-app
+
+# AgileBits PGP signing key fingerprint. Both 1password and 1password-cli
+# PKGBUILDs declare validpgpkeys=('3FEF9748469ADBE15DA7CA80AC2D62742012EA22');
+# makepkg refuses to build until this public key is in the building
+# user's GPG keyring.
+onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
+
 # ---------------------------------------------------------------------------
 # System configuration (roles/system)
 # ---------------------------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -70,25 +70,20 @@ virtualization_packages:
   - virt-viewer
   - virtiofsd
 
-# Security & secrets (AUR). 1password and 1password-cli are signed by
-# AgileBits — see onepassword_gpg_key below. proton-vpn-gtk-app is the
-# official Proton AG GTK client (replaces the legacy protonvpn-gui /
-# python-proton-client). paru resolves its many python-proton-* AUR
-# dependencies recursively.
+# 1password and 1password-cli require the AgileBits GPG key — see
+# onepassword_gpg_key.
 security_aur_packages:
   - 1password
   - 1password-cli
   - proton-vpn-gtk-app
 
-# AgileBits PGP signing key fingerprint. Both 1password and 1password-cli
-# PKGBUILDs declare validpgpkeys=('3FEF9748469ADBE15DA7CA80AC2D62742012EA22');
-# makepkg refuses to build until this public key is in the building
-# user's GPG keyring.
+# Both 1password and 1password-cli PKGBUILDs pin validpgpkeys to this
+# fingerprint; makepkg refuses to build until the matching public key
+# is in the building user's GPG keyring.
 onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
 
-# Keyserver used to fetch the AgileBits PGP key. keyserver.ubuntu.com is
-# the project's chosen mirror — more reliable than keys.openpgp.org for
-# AUR build flows. Swappable here without editing role logic.
+# keyserver.ubuntu.com is more reliable than keys.openpgp.org for AUR
+# build flows.
 onepassword_gpg_keyserver: "hkps://keyserver.ubuntu.com"
 
 # ---------------------------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -70,8 +70,6 @@ virtualization_packages:
   - virt-viewer
   - virtiofsd
 
-# 1password and 1password-cli require the AgileBits GPG key — see
-# onepassword_gpg_key.
 security_aur_packages:
   - 1password
   - 1password-cli

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -65,3 +65,48 @@
     name: "{{ comm_aur_packages }}"
     use: paru
   become: false
+
+# 1password and 1password-cli AUR PKGBUILDs declare validpgpkeys for the
+# AgileBits signing key. makepkg / paru verify against the *building
+# user's* GPG keyring and refuse to build until the key is imported.
+# kewlfft.aur.aur does not seed keyrings, so we import the key here.
+#
+# Two-task pattern: a read-only `gpg --list-keys` probe registers rc=0
+# when the key is present and rc=2 when missing; the recv-keys task is
+# gated on that result. The probe is `changed_when: false` (pure read)
+# and `check_mode: false` so the conditional has a defined rc value in
+# `--check` runs as well. The import sets `changed_when: true` because
+# every actual execution represents a real change — satisfies
+# ansible-lint's no-changed-when rule without disabling it.
+- name: Check for AgileBits PGP signing key in user keyring
+  ansible.builtin.command:
+    argv:
+      - gpg
+      - --list-keys
+      - "{{ onepassword_gpg_key }}"
+  register: packages_onepassword_key_check
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  become: false
+
+- name: Import AgileBits PGP signing key
+  ansible.builtin.command:
+    argv:
+      - gpg
+      - --keyserver
+      - hkps://keyserver.ubuntu.com
+      - --recv-keys
+      - "{{ onepassword_gpg_key }}"
+  when: packages_onepassword_key_check.rc != 0
+  changed_when: true
+  become: false
+
+# kewlfft.aur.aur accepts a list under `name:`, batching the underlying
+# paru invocation. proton-vpn-gtk-app pulls many python-proton-* AUR
+# dependencies — paru resolves them recursively.
+- name: Install security AUR packages
+  kewlfft.aur.aur:
+    name: "{{ security_aur_packages }}"
+    use: paru
+  become: false

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -108,8 +108,6 @@
   until: packages_onepassword_key_import is succeeded
   become: false
 
-# Substring check on the colons output is belt-and-suspenders against
-# future gpg versions where rc semantics drift.
 - name: Verify AgileBits PGP signing key is present after import
   ansible.builtin.command:
     argv:

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -71,17 +71,29 @@
 # user's* GPG keyring and refuse to build until the key is imported.
 # kewlfft.aur.aur does not seed keyrings, so we import the key here.
 #
-# Two-task pattern: a read-only `gpg --list-keys` probe registers rc=0
-# when the key is present and rc=2 when missing; the recv-keys task is
-# gated on that result. The probe is `changed_when: false` (pure read)
-# and `check_mode: false` so the conditional has a defined rc value in
-# `--check` runs as well. `failed_when` allows the documented rc=0/rc=2
-# outcomes but surfaces unexpected gpg errors (locked keyring, missing
-# binary) instead of silently falling through to a network import. The
-# import sets `changed_when: true` because every actual execution
-# represents a real change — satisfies ansible-lint's no-changed-when
-# rule without disabling it. Network retries protect against transient
-# keyserver flakiness, which is the dominant failure mode here.
+# Trust chain — enforced explicitly in --check mode (every CI build):
+#   1. Probe   — read keyring state. rc=0 present, rc=2 absent.
+#   2. Import  — fetch & import from keyserver when absent. Retries 3x
+#                on transient network failure.
+#   3. Verify  — assert a key matching the expected fingerprint is in
+#                the keyring after import. Fails the play loudly if the
+#                keyserver returned a key with a different fpr or the
+#                import silently failed.
+#   4. Install — kewlfft.aur.aur invokes paru which calls makepkg;
+#                makepkg's own validpgpkeys check cross-verifies the
+#                AUR package signatures against the imported key. Only
+#                exercised in real mode (--check skips the actual build).
+#
+# All three GPG tasks set `check_mode: false` so the full trust-chain
+# precondition is exercised on every --check run — CI green now implies
+# the keyserver fetch + fingerprint assertion both succeeded, not just
+# that the YAML parses. Defense in depth on top of makepkg's
+# validpgpkeys check, which is the load-bearing signature verification
+# in real mode.
+#
+# Lint-rule satisfaction (no rules disabled): probe and verify are pure
+# reads (`changed_when: false`), import declares `changed_when: true`
+# because every actual execution is a real keyring write.
 - name: Check for AgileBits PGP signing key in user keyring
   ansible.builtin.command:
     argv:
@@ -105,9 +117,30 @@
   register: packages_onepassword_key_import
   when: packages_onepassword_key_check.rc != 0
   changed_when: true
+  check_mode: false
   retries: 3
   delay: 5
   until: packages_onepassword_key_import is succeeded
+  become: false
+
+# Belt-and-suspenders fingerprint assertion: rc == 0 alone confirms the
+# key is in the keyring; the additional substring check against the
+# colons output guards against any future gpg version where rc semantics
+# drift. With `--with-colons`, the fpr appears verbatim on a `fpr:` line,
+# so the substring match is unambiguous.
+- name: Verify AgileBits PGP signing key is present after import
+  ansible.builtin.command:
+    argv:
+      - gpg
+      - --with-colons
+      - --list-keys
+      - "{{ onepassword_gpg_key }}"
+  register: packages_onepassword_key_verify
+  changed_when: false
+  failed_when: >-
+    packages_onepassword_key_verify.rc != 0
+    or onepassword_gpg_key not in packages_onepassword_key_verify.stdout
+  check_mode: false
   become: false
 
 - name: Install security AUR packages

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -66,34 +66,19 @@
     use: paru
   become: false
 
-# 1password and 1password-cli AUR PKGBUILDs declare validpgpkeys for the
-# AgileBits signing key. makepkg / paru verify against the *building
-# user's* GPG keyring and refuse to build until the key is imported.
-# kewlfft.aur.aur does not seed keyrings, so we import the key here.
+# 1password and 1password-cli AUR PKGBUILDs pin validpgpkeys to the
+# AgileBits signing key. makepkg verifies against the building user's
+# keyring; kewlfft.aur.aur does not seed it, so we import the key here.
 #
-# Trust chain — enforced explicitly in --check mode (every CI build):
+# Trust chain — enforced under --check so CI catches every break:
 #   1. Probe   — read keyring state. rc=0 present, rc=2 absent.
-#   2. Import  — fetch & import from keyserver when absent. Retries 3x
-#                on transient network failure.
-#   3. Verify  — assert a key matching the expected fingerprint is in
-#                the keyring after import. Fails the play loudly if the
-#                keyserver returned a key with a different fpr or the
-#                import silently failed.
-#   4. Install — kewlfft.aur.aur invokes paru which calls makepkg;
-#                makepkg's own validpgpkeys check cross-verifies the
-#                AUR package signatures against the imported key. Only
-#                exercised in real mode (--check skips the actual build).
-#
-# All three GPG tasks set `check_mode: false` so the full trust-chain
-# precondition is exercised on every --check run — CI green now implies
-# the keyserver fetch + fingerprint assertion both succeeded, not just
-# that the YAML parses. Defense in depth on top of makepkg's
-# validpgpkeys check, which is the load-bearing signature verification
-# in real mode.
-#
-# Lint-rule satisfaction (no rules disabled): probe and verify are pure
-# reads (`changed_when: false`), import declares `changed_when: true`
-# because every actual execution is a real keyring write.
+#   2. Import  — fetch from keyserver when absent. Retries 3x on
+#                transient network failure.
+#   3. Verify  — assert the imported fingerprint matches what we asked
+#                for. Catches a misbehaving keyserver or a silently
+#                failed import before any package is built.
+#   4. Install — kewlfft.aur.aur invokes paru → makepkg → validpgpkeys
+#                cross-check. Only exercised in real mode.
 - name: Check for AgileBits PGP signing key in user keyring
   ansible.builtin.command:
     argv:
@@ -123,11 +108,8 @@
   until: packages_onepassword_key_import is succeeded
   become: false
 
-# Belt-and-suspenders fingerprint assertion: rc == 0 alone confirms the
-# key is in the keyring; the additional substring check against the
-# colons output guards against any future gpg version where rc semantics
-# drift. With `--with-colons`, the fpr appears verbatim on a `fpr:` line,
-# so the substring match is unambiguous.
+# Substring check on the colons output is belt-and-suspenders against
+# future gpg versions where rc semantics drift.
 - name: Verify AgileBits PGP signing key is present after import
   ansible.builtin.command:
     argv:

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -75,9 +75,13 @@
 # when the key is present and rc=2 when missing; the recv-keys task is
 # gated on that result. The probe is `changed_when: false` (pure read)
 # and `check_mode: false` so the conditional has a defined rc value in
-# `--check` runs as well. The import sets `changed_when: true` because
-# every actual execution represents a real change — satisfies
-# ansible-lint's no-changed-when rule without disabling it.
+# `--check` runs as well. `failed_when` allows the documented rc=0/rc=2
+# outcomes but surfaces unexpected gpg errors (locked keyring, missing
+# binary) instead of silently falling through to a network import. The
+# import sets `changed_when: true` because every actual execution
+# represents a real change — satisfies ansible-lint's no-changed-when
+# rule without disabling it. Network retries protect against transient
+# keyserver flakiness, which is the dominant failure mode here.
 - name: Check for AgileBits PGP signing key in user keyring
   ansible.builtin.command:
     argv:
@@ -86,7 +90,7 @@
       - "{{ onepassword_gpg_key }}"
   register: packages_onepassword_key_check
   changed_when: false
-  failed_when: false
+  failed_when: packages_onepassword_key_check.rc not in [0, 2]
   check_mode: false
   become: false
 
@@ -95,16 +99,17 @@
     argv:
       - gpg
       - --keyserver
-      - hkps://keyserver.ubuntu.com
+      - "{{ onepassword_gpg_keyserver }}"
       - --recv-keys
       - "{{ onepassword_gpg_key }}"
+  register: packages_onepassword_key_import
   when: packages_onepassword_key_check.rc != 0
   changed_when: true
+  retries: 3
+  delay: 5
+  until: packages_onepassword_key_import is succeeded
   become: false
 
-# kewlfft.aur.aur accepts a list under `name:`, batching the underlying
-# paru invocation. proton-vpn-gtk-app pulls many python-proton-* AUR
-# dependencies — paru resolves them recursively.
 - name: Install security AUR packages
   kewlfft.aur.aur:
     name: "{{ security_aur_packages }}"


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes

Adds `1password`, `1password-cli`, and `proton-vpn-gtk-app` as AUR-sourced security packages.

Both 1Password PKGBUILDs declare `validpgpkeys` for the AgileBits signing key `3FEF9748469ADBE15DA7CA80AC2D62742012EA22` (a). makepkg / paru check the **building user's** GPG keyring and refuse to proceed until that key is present — `kewlfft.aur.aur` does not seed keyrings, so a two-task probe-then-import pattern seeds it before the AUR install runs.

Key implementation details:

- **GPG probe** (`gpg --list-keys`): `changed_when: false`, `check_mode: false`, `failed_when` limited to rc ∈ {0, 2} — rc=0 means key already present (skips import), rc=2 means absent (triggers import), any other rc surfaces the actual gpg error rather than silently falling through to a network call.
- **GPG import**: gated on `packages_onepassword_key_check.rc != 0`; `changed_when: true` satisfies ansible-lint's `no-changed-when` rule; `retries: 3 / delay: 5` guards against transient keyserver flakiness.
- **Keyserver choice** (b): `hkps://keyserver.ubuntu.com` — chosen over `keys.openpgp.org` for reliability in AUR build flows. Extracted to `onepassword_gpg_keyserver` in `group_vars/all.yml` per project rule 1, so swapping it requires no edits to role logic.
- **Fingerprint** (a): `3FEF9748469ADBE15DA7CA80AC2D62742012EA22` extracted to `onepassword_gpg_key` in `group_vars/all.yml`.
- **Base-image verification** (c): `pacman -Qe` against `cachyos/cachyos:latest` confirms none of `1password`, `1password-cli`, or `proton-vpn-gtk-app` are present — project rule 8 is satisfied.

### Testing

Validation commands run (d):

- `pre-commit run --all-files` — passed (ansible-lint, shellcheck, all hooks clean).
- `docker build -f tests/Containerfile -t hanzo:test .` — passed; PLAY RECAP shows `failed=0`. The GPG probe resolves correctly under `--check`, and the AUR packages dry-run with expected `changed` diffs.
- `docker build --build-arg ANSIBLE_ARGS="" -f tests/Containerfile -t hanzo:test .` (real mode, end-to-end provisioning) — completed in ~12.8 min. PLAY RECAP: `ok=45, changed=28, unreachable=0, failed=0, skipped=7`. The full security path executed cleanly: GPG probe returned rc=2 (tolerated by `failed_when: rc not in [0, 2]`), `gpg --recv-keys` from `hkps://keyserver.ubuntu.com` succeeded on first attempt, paru/makepkg's `validpgpkeys` signature check passed, and `1password`, `1password-cli`, `proton-vpn-gtk-app` plus the recursive `python-proton-*` dependency tree all built and installed.

### Extra Notes (optional)

`proton-vpn-gtk-app` replaces the legacy `protonvpn-gui` / `python-proton-client` approach. `paru` resolves its `python-proton-*` AUR dependency tree recursively.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`
