### PR TITLE
feat(packages): add Chrome, Moonlight-QT, Spotify desktop apps

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -46,9 +46,14 @@ gaming_packages:
 comm_packages:
   - signal-desktop
 
+desktop_packages:
+  - moonlight-qt
+  - spotify-launcher
+
 aur_packages:
   - claude-desktop-bin
   - fnm-bin
+  - google-chrome
   - wifiman-desktop
 
 comm_aur_packages:

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -47,6 +47,11 @@
     name: "{{ comm_packages }}"
   become: true
 
+- name: Install desktop applications
+  community.general.pacman:
+    name: "{{ desktop_packages }}"
+  become: true
+
 # kewlfft.aur.aur accepts a list under `name:`, batching the underlying
 # paru invocation. Avoids per-iteration paru startup + AUR DB read cost.
 - name: Install AUR packages


### PR DESCRIPTION
### Related Issues

Internal task #1 (no GitHub issue; designated by team lead as an internal task).

### Proposed Changes

Adds three desktop applications to the provisioner:

- **Google Chrome** — installed via AUR (`google-chrome`), handled by the existing `kewlfft.aur.aur` task using `paru`.
- **Moonlight-QT** — game-streaming client, installed from the official `extra` repo.
- **Spotify** — installed via `spotify-launcher` from the official `extra` repo.

Implementation follows project conventions:

- Package names live in `group_vars/all.yml` under a new `desktop_packages` list (`moonlight-qt`, `spotify-launcher`) and `google-chrome` is appended to `aur_packages`. No package names are hardcoded in task files (Rule 1).
- A dedicated `Install desktop applications` task is added to `roles/packages/tasks/main.yml` using `community.general.pacman` with `become: true`, keeping it separate from gaming packages (Rule 6).
- The existing `Install AUR packages` task already uses `kewlfft.aur.aur` and picks up `google-chrome` automatically — no new task required for AUR.

### Testing

All three audit artifacts below confirm the packages are safe to add and install cleanly.

## Audit Trail

### CachyOS base-image collision check

Verifies none of the three packages are already present in `cachyos/cachyos:latest`, satisfying Rule 8.

```
warning: database file for 'cachyos' does not exist (use '-Sy' to download)
warning: database file for 'core' does not exist (use '-Sy' to download)
warning: database file for 'extra' does not exist (use '-Sy' to download)
warning: database file for 'multilib' does not exist (use '-Sy' to download)
NOT PRESENT — safe to add
```

Command: `docker run --rm --platform linux/amd64 cachyos/cachyos:latest pacman -Qe | grep -E '^(google-chrome|moonlight-qt|spotify(-launcher)?)[[:space:]]' || echo "NOT PRESENT — safe to add"`

### Repo resolution

Confirms `moonlight-qt` and `spotify-launcher` resolve against the official `extra` repository (not AUR), as assumed by the `community.general.pacman` task.

```
Repository      : extra
Name            : moonlight-qt
Repository      : extra
Name            : spotify-launcher
```

Command: `docker run --rm --platform linux/amd64 cachyos/cachyos:latest sh -c 'pacman -Sy >/dev/null && pacman -Si moonlight-qt spotify-launcher | grep -E "^(Name|Repository)"'`

### Real-install confirmation

`docker build --build-arg ANSIBLE_ARGS="" -f tests/Containerfile -t hanzo:test .` completed with exit code 0.

PLAY RECAP: `ok=43 changed=27 unreachable=0 failed=0 skipped=7`. The `Install desktop applications` task and the `Install AUR packages` task both reported `changed: [localhost]`, confirming `moonlight-qt` and `spotify-launcher` resolved against the live `extra` repo and `google-chrome` built and installed today via paru. Total wall time: **13:01.43** (~13 minutes; ansible run 629s, image export 102s).

### Extra Notes (optional)

`spotify-launcher` is the Arch-maintained wrapper that downloads and sandboxes the official Spotify binary. It is the correct package for Arch-based systems (not the AUR `spotify` package which requires manual PKGBUILD maintenance).

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`