### PR TITLE
feat(hardware): grant uaccess to GZ302 lightbar USB device

### DIFF
--- a/roles/hardware/templates/99-gz302-rgb.rules.j2
+++ b/roles/hardware/templates/99-gz302-rgb.rules.j2
@@ -1,6 +1,7 @@
 # ASUS ROG Flow Z13 (GZ302) -- RGB unprivileged USB access
 # Managed by Hanzo. Do not edit manually.
 #
-# Grants unprivileged access to the ASUS keyboard USB device so that
-# rog-control-center can control RGB without running as root.
+# Grants unprivileged access to the ASUS keyboard and lightbar USB devices
+# so that rog-control-center can control RGB without running as root.
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="{{ gz302_asus_usb_vendor }}", ATTRS{idProduct}=="{{ gz302_asus_keyboard_product }}", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="{{ gz302_asus_usb_vendor }}", ATTRS{idProduct}=="{{ gz302_asus_lightbar_product }}", TAG+="uaccess"


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

Add a `uaccess` udev rule for the GZ302 ASUS lightbar USB device (`0b05:18c6`) in `roles/hardware/templates/99-gz302-rgb.rules.j2`, alongside the existing keyboard rule. Also refreshes the file header comment to mention both devices.

## Rationale

The current configuration is internally inconsistent. The role's:

- `group_vars/all.yml:147` defines `gz302_asus_lightbar_product: "18c6"`.
- `roles/hardware/templates/gz302-suspend.sh.j2` references that product ID when cycling USB authorization on resume (`reset_usb_device "$dev" "lightbar"`).
- `roles/hardware/templates/99-gz302-rgb.rules.j2` grants `uaccess` only to the keyboard.

A userspace daemon (asusctl/rog-control-center, which the repo already installs via `asus_packages` in `group_vars/all.yml`) driving the lightbar would need root because its USB device has no session ACL. `TAG+="uaccess"` is the systemd-logind mechanism that propagates an ACL to the active local session user; `SUBSYSTEMS=="usb"` matching is correct (it walks parents so `ATTRS` resolve, and the ACL propagates to all child nodes — hidraw, usbN, input/eventX — which is what userspace actually opens). This is the OpenRGB-recommended form.

CachyOS-Settings ships zero ASUS udev rules; asusctl's `asusd.rules` only fires the `asusd.service` on `asus-nb-wmi` DMI match and does not grant `0b05:18c6` ACLs. So the rule is not redundant.

### Testing:

- Container test: `docker build -f tests/Containerfile -t hanzo:test .`
- Lint: `pre-commit run --all-files`

### Extra Notes (optional):

The change is a one-line addition to the existing udev rules template plus a comment update. No new variables are introduced — `gz302_asus_lightbar_product` is already defined in `group_vars/all.yml`.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`