### PR TITLE
fix(hardware): remove hid_asus fnlock_default no-op

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -138,9 +138,6 @@ gz302_amdgpu_sg_display: 0
 # Disable Compute Wavefront Save-Restore to prevent GPU hangs on RDNA 3.5.
 gz302_amdgpu_cwsr_enable: 0
 
-# F-row defaults to media keys; press Fn for standard F1-F12.
-gz302_hid_fnlock_default: 0
-
 # ASUS USB identifiers for keyboard, touchpad, and lightbar devices.
 gz302_asus_usb_vendor: "0b05"
 gz302_asus_keyboard_product: "1a30"

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -1,21 +1,13 @@
 ---
 # ASUS ROG Flow Z13 (GZ302) hardware fixes.
 #
-# Fixes: GPU modprobe, HID modprobe, OLED kernel param, initramfs,
+# Fixes: GPU modprobe, OLED kernel param, initramfs,
 # suspend hook, keyboard hwdb remap, RGB udev rule.
 
 - name: Deploy GPU modprobe config
   ansible.builtin.template:
     src: amdgpu.conf.j2
     dest: /etc/modprobe.d/amdgpu.conf
-    mode: "0644"
-  become: true
-  notify: Rebuild initramfs
-
-- name: Deploy HID modprobe config
-  ansible.builtin.template:
-    src: hid_asus.conf.j2
-    dest: /etc/modprobe.d/hid_asus.conf
     mode: "0644"
   become: true
   notify: Rebuild initramfs

--- a/roles/hardware/templates/hid_asus.conf.j2
+++ b/roles/hardware/templates/hid_asus.conf.j2
@@ -1,6 +1,0 @@
-# ASUS HID configuration for GZ302
-# Managed by Hanzo. Do not edit manually.
-
-# fnlock_default={{ gz302_hid_fnlock_default }}: F1-F12 keys act as media/function keys by default.
-# Press Fn to get standard F1-F12 behavior.
-options hid_asus fnlock_default={{ gz302_hid_fnlock_default }}


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes

Removed the `hid_asus.conf` modprobe drop-in and its backing variable `gz302_hid_fnlock_default` because the directive was a silent no-op: `fnlock_default` is not a parameter of the `hid_asus` kernel module.

**Kernel source evidence**

`fnlock_default` lives in the `asus_wmi` driver, not `hid_asus`:

```c
// drivers/platform/x86/asus-wmi.c
static bool fnlock_default = true;
module_param(fnlock_default, bool, 0444);
```

`drivers/hid/hid-asus.c` declares zero `module_param` entries and contains zero `fnlock` references:

```
$ grep -c module_param drivers/hid/hid-asus.c
0
```

**Runtime behavior**

`modprobe` logged `ignoring bad option fnlock_default` and loaded `hid_asus` with no parameters — the directive had no effect whatsoever.

**Origin**

The bug was inherited from `th3cavalry/GZ302-Linux-Setup`, which carries the same defect.

**Why delete rather than retarget**

The upstream `asus_wmi.fnlock_default` default is already `true`, which matches the desired media-key behavior. A corrected drop-in targeting `asus_wmi` would be a redundant default-equal-default override with no observable effect.

**What stays**

The `Rebuild initramfs` handler is preserved. The GPU modprobe task and the OLED kernel-param task still notify it, so no handler plumbing needs to change.

### Testing

- [ ] `pre-commit run --all-files` passes
- [ ] `docker build -f tests/Containerfile -t hanzo:test .` passes
- [ ] No remaining `hid_asus`, `fnlock`, or `gz302_hid_fnlock` references in the tree

### Extra Notes (optional)

The three deleted artifacts are: `group_vars/all.yml` variable `gz302_hid_fnlock_default`, the task "Deploy HID modprobe config" in `roles/hardware/tasks/gz302.yml`, and the template `roles/hardware/templates/hid_asus.conf.j2`.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`