### PR TITLE
fix(hardware): reduce gz302 amdgpu.dcdebugmask to 0x400

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -124,9 +124,11 @@ claude_config_dir: ~/.claude
 # GZ302 (ASUS ROG Flow Z13) hardware configuration (roles/hardware)
 # ---------------------------------------------------------------------------
 
-# OLED kernel param: disables PSR-SU and Panel Replay to prevent scrolling
-# artifacts and flicker on the Strix Halo OLED panel (kernel 7.0+).
-gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x600"
+# Disable Panel Replay (DC_DISABLE_REPLAY=0x400) on the Strix Halo OLED panel.
+# PSR-SU is already globally disabled in mainline 7.0 via link_supports_psrsu()
+# returning false (commit 6deeefb820d0), so 0x200 is redundant — only 0x400 is
+# load-bearing. Revisit at Linux 7.2 (AMDGPU Power Module rework).
+gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x400"
 
 # Force ABM off: kernel auto-skip on OLED was reverted in 2024; PPD engages
 # ABM on battery and causes visible gamma/red-shift on AMD OLED panels.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -124,10 +124,8 @@ claude_config_dir: ~/.claude
 # GZ302 (ASUS ROG Flow Z13) hardware configuration (roles/hardware)
 # ---------------------------------------------------------------------------
 
-# Disable Panel Replay (DC_DISABLE_REPLAY=0x400) on the Strix Halo OLED panel.
-# PSR-SU is already globally disabled in mainline 7.0 via link_supports_psrsu()
-# returning false (commit 6deeefb820d0), so 0x200 is redundant — only 0x400 is
-# load-bearing. Revisit at Linux 7.2 (AMDGPU Power Module rework).
+# Disable Panel Replay (DC_DISABLE_REPLAY=0x400) on the Strix Halo OLED panel
+# to prevent scrolling artifacts and flicker on DCN 3.5.
 gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x400"
 
 # Force ABM off: kernel auto-skip on OLED was reverted in 2024; PPD engages


### PR DESCRIPTION
### Related Issues

N/A — internal task

### Proposed Changes

Reduce `gz302_oled_kernel_param` in `group_vars/all.yml` from
`amdgpu.dcdebugmask=0x600` to `amdgpu.dcdebugmask=0x400`.

**Mask decomposition:**
`0x600 = DC_DISABLE_PSR_SU (0x200) | DC_DISABLE_REPLAY (0x400)`

The `0x200` bit (PSR-SU) is now dead weight on Linux 7.0+.
`link_supports_psrsu()` in
`drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_psr.c`
unconditionally returns `false` since commit `6deeefb820d0` (Feb 2026,
backported to 6.1.130-rc1). The AMDGPU DC layer therefore disables
PSR-SU globally at the driver level regardless of the kernel command
line, making the `0x200` flag a no-op.

Only `0x400` (DC_DISABLE_REPLAY) remains load-bearing on Strix Halo —
there is no upstream global Panel Replay disable for DCN 3.5 yet.

The mask was deliberately **not** broadened to `0xe12`
(DC_DISABLE_STUTTER | DC_DISABLE_CLOCK_GATING | …): those bits would
regress s2idle power residency and contradict upstream guidance.

**Revisit milestone:** Linux 7.2, when the AMDGPU Power Module rework
lands — at that point Panel Replay support for Strix Halo may arrive
upstream and `0x400` could be dropped entirely.

**No task-file change required.** The `lineinfile` task in
`roles/hardware/tasks/gz302.yml` matches by the `dcdebugmask=` key, so
the new value is rewritten in place on the next provision run and the
Rebuild initramfs handler fires automatically.

### Testing

- [ ] `pre-commit run --all-files` — lint passes (YAML/Ansible only, no logic change)
- [ ] `docker build -f tests/Containerfile -t hanzo:test .` — container check passes

### Extra Notes (optional)

Commit `6deeefb820d0` landing in the 6.1.130-rc1 stable backport
confirms the fix is present on the CachyOS LTS kernel track, not just
mainline.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`