### PR TITLE
refactor(hardware): drop ppfeaturemask, correct amdgpu comments

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -128,12 +128,10 @@ claude_config_dir: ~/.claude
 # artifacts and flicker on the Strix Halo OLED panel (kernel 7.0+).
 gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x600"
 
-# GPU modprobe options for Radeon 8060S (RDNA 3.5, Strix Halo).
-# All power features except GFXOFF (bit 15) which causes GPU hangs.
-gz302_amdgpu_ppfeaturemask: "0xffff7fff"
-# Disable Adaptive Backlight Management (not applicable to OLED panels).
+# Force ABM off: kernel auto-skip on OLED was reverted in 2024; PPD engages
+# ABM on battery and causes visible gamma/red-shift on AMD OLED panels.
 gz302_amdgpu_abmlevel: 0
-# Disable scatter-gather display to prevent OLED flicker under memory pressure.
+# Disable scatter-gather display to prevent flicker on unified-memory APUs under memory pressure.
 gz302_amdgpu_sg_display: 0
 # Disable Compute Wavefront Save-Restore to prevent GPU hangs on RDNA 3.5.
 gz302_amdgpu_cwsr_enable: 0

--- a/roles/hardware/templates/amdgpu.conf.j2
+++ b/roles/hardware/templates/amdgpu.conf.j2
@@ -1,18 +1,18 @@
 # AMD GPU configuration for Radeon 8060S (RDNA 3.5, Strix Halo)
 # Managed by Hanzo. Do not edit manually.
 
-# {{ gz302_amdgpu_ppfeaturemask }}: all power feature bits enabled except bit 15 (GFXOFF).
-# GFXOFF causes GPU hangs under rapid power-state transitions on the
-# Strix Halo iGPU.
-options amdgpu ppfeaturemask={{ gz302_amdgpu_ppfeaturemask }}
-
-# Disable Adaptive Backlight Management. Not applicable to OLED panels
-# (driver skips ABM when DPCD reports oled=1), but explicit disable is
-# belt-and-suspenders.
+# Force ABM off. The kernel patch that auto-skipped ABM on OLED panels
+# (76cb763e6ea6) was reverted in 2024 — ABM is still active on OLED in 7.0
+# mainline, and power-profiles-daemon ≥0.20 engages it on battery via
+# panel_power_savings, producing visible gamma/red-shift on this OLED panel.
 options amdgpu abmlevel={{ gz302_amdgpu_abmlevel }}
 
-# Disable scatter-gather display on this APU. Prevents OLED flicker
-# under memory pressure.
+# Disable scatter-gather display on this unified-memory APU. Per amdgpu
+# kernel docs: "Disable S/G display if you experience flickering or other
+# issues under memory pressure." Under pressure, pageable scanout pages
+# can be migrated/reclaimed faster than DC can refetch, producing torn
+# lines. The bug is APU+memory-pressure, not OLED-specific (OLED only
+# makes the artifact more visually obvious).
 options amdgpu sg_display={{ gz302_amdgpu_sg_display }}
 
 # Disable Compute Wavefront Save-Restore. Prevents GPU hangs and


### PR DESCRIPTION
### Related Issues

N/A — maintenance cleanup, no tracked issue.

### Proposed Changes

Three targeted changes to `amdgpu.conf.j2` and `group_vars/all.yml`, each motivated by a concrete upstream behaviour change:

**1. Drop `ppfeaturemask=0xffff7fff` (GFXOFF workaround removed)**

The mask was introduced to disable bit 15 (GFXOFF) which caused GPU hangs under rapid power-state transitions on the Strix Halo iGPU running kernels 6.14–6.17. CachyOS now ships kernel 7.0.8, and the AMD ROCm Strix Halo bring-up guide lists 6.18.4 as the minimum where the GFXOFF fix landed. The workaround is no longer needed and actively prevents the firmware from using its full power-management surface.

**2. Rewrite the `abmlevel=0` comment**

The previous comment said "not applicable to OLED panels (driver skips ABM when DPCD reports oled=1)". That was wrong. Kernel patch `76cb763e6ea6`, which auto-skipped ABM on OLED panels, was reverted in 2024 and is absent from 7.0 mainline. ABM remains active on OLED. Additionally, `power-profiles-daemon` ≥0.20 engages ABM on battery via `panel_power_savings`, producing visible gamma shift and red tinting on the OLED display. The explicit `abmlevel=0` is still correct; the justification now reflects the actual reason.

**3. Rewrite the `sg_display=0` comment**

The previous comment attributed OLED flicker solely to OLED panel characteristics. The real root cause is unified-memory APU architecture: under memory pressure, pageable scanout pages can be migrated or reclaimed faster than the display controller can refetch them, producing torn scan lines. The OLED panel only makes the visual artefact more apparent; the bug affects any display on an APU under memory pressure. The new comment quotes the upstream `amdgpu` kernel docs directly and correctly scopes the bug.

### Testing

- `pre-commit run --all-files` — lint passes (no task logic changed, only variable removal and comment rewrites).
- `docker build -f tests/Containerfile -t hanzo:test .` — container provisioning check passes; `ppfeaturemask` option is no longer written to `/etc/modprobe.d/amdgpu.conf`.

### Extra Notes (optional)

The `gz302_amdgpu_ppfeaturemask` variable is removed from `group_vars/all.yml` entirely. Any downstream reference to that variable (e.g. in a future role) will fail loudly at render time, which is the desired behaviour — the workaround should not silently reappear.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`