### PR TITLE
feat(hardware): disable MT7925 Wi-Fi powersave via NM drop-in

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -147,7 +147,13 @@ gz302_keyboard_scancode: "70072"
 gz302_keyboard_target_key: prog1
 
 # NetworkManager wifi.powersave for MT7925. NM's default (3 = enabled)
-# causes disconnects and throttled throughput on this chip.
+# causes disconnects and throttled throughput on this chip; 2 = disabled is
+# the cross-distro workaround (Arch, Fedora, Framework, Z13 communities).
+# Trade-off: ~1-2% extra system idle power; does NOT affect suspend (the
+# mt7925_pci_suspend driver callback is a separate code path from runtime
+# nl80211 PS). 1 = ignore is not a substitute because the mt76 driver
+# default is PS-on (the 2023 patch to flip it was rejected upstream).
+# Flip back to 3 if a future kernel/firmware combo fixes the regression.
 # Values: 0 = use default, 1 = ignore, 2 = disable, 3 = enable.
 gz302_wifi_powersave: 2
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -146,6 +146,10 @@ gz302_asus_lightbar_product: "18c6"
 gz302_keyboard_scancode: "70072"
 gz302_keyboard_target_key: prog1
 
+# NetworkManager wifi powersave for MT7925: 2 = disabled. NM default is 3
+# (enabled), which causes disconnects/slow throughput on this chip.
+gz302_wifi_powersave: 2
+
 # ---------------------------------------------------------------------------
 # Development tools (roles/devtools, roles/infra)
 # ---------------------------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -146,8 +146,9 @@ gz302_asus_lightbar_product: "18c6"
 gz302_keyboard_scancode: "70072"
 gz302_keyboard_target_key: prog1
 
-# NetworkManager wifi powersave for MT7925: 2 = disabled. NM default is 3
-# (enabled), which causes disconnects/slow throughput on this chip.
+# NetworkManager wifi.powersave for MT7925. NM's default (3 = enabled)
+# causes disconnects and throttled throughput on this chip.
+# Values: 0 = use default, 1 = ignore, 2 = disable, 3 = enable.
 gz302_wifi_powersave: 2
 
 # ---------------------------------------------------------------------------

--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -19,3 +19,9 @@
     udevadm trigger
   changed_when: true
   become: true
+
+- name: Reload NetworkManager
+  ansible.builtin.systemd_service:
+    name: NetworkManager
+    state: reloaded
+  become: true

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -42,3 +42,11 @@
     mode: "0644"
   become: true
   notify: Reload udev rules
+
+- name: Deploy NetworkManager wifi powersave drop-in
+  ansible.builtin.template:
+    src: wifi-powersave.conf.j2
+    dest: /etc/NetworkManager/conf.d/wifi-powersave.conf
+    mode: "0644"
+  become: true
+  notify: Reload NetworkManager

--- a/roles/hardware/templates/wifi-powersave.conf.j2
+++ b/roles/hardware/templates/wifi-powersave.conf.j2
@@ -1,0 +1,7 @@
+# MediaTek MT7925 NetworkManager powersave override
+# Managed by Hanzo. Do not edit manually.
+#
+# NM defaults to wifi.powersave=3 (enabled). On MT7925 this causes
+# disconnects, throttled upload, and slow throughput. Set to 2 (disabled).
+[connection]
+wifi.powersave = {{ gz302_wifi_powersave }}


### PR DESCRIPTION
### Related Issues

N/A — hardware quirk fix, no tracking issue.

### Proposed Changes

Disable NetworkManager Wi-Fi power-save (`wifi.powersave = 2`) for the MediaTek
MT7925 Wi-Fi chip in the GZ302. Implemented as a NetworkManager `conf.d/`
drop-in deployed by `roles/hardware` and gated by the existing GZ302 DMI +
container detection, so it only applies on real GZ302 hardware.

**Rationale**

The MT7925 Wi-Fi chip in the GZ302 has well-documented stability issues with
NetworkManager's default `wifi.powersave=3` (enabled): disconnects, throttled
upload (~200 Mbps vs 1.2 Gbps), slow speeds. Reported on Garuda, Fedora 42,
Arch, Framework 13, and Z13 2025 forums; a 2023 `mt76` patch attempted
driver-side default-off but NM still flips it on at the link layer.

This is hardware-driven (MT7925 quirk), not a generic preference, so applying
it conditionally on GZ302 detection is correct. The base CachyOS image ships
exactly one `NetworkManager/conf.d/` file (`dns.conf`); no `wifi.powersave`
override exists. Files in `/etc/NetworkManager/conf.d/` override `/usr/lib/`,
so our drop-in is not redundant with or shadowed by upstream.

Value `2` per NetworkManager docs: 0=default, 1=ignore, 2=disable, 3=enable.

**What changed**

- New template: `roles/hardware/templates/wifi-powersave.conf.j2`
- New variable: `gz302_wifi_powersave: 2` in `group_vars/all.yml`
- New task in `roles/hardware/tasks/gz302.yml`
- New handler `Reload NetworkManager` in `roles/hardware/handlers/main.yml`
  using `ansible.builtin.systemd_service` (`state: reloaded`)

### Testing

- [x] `pre-commit run --all-files` passes
- [x] `docker build -f tests/Containerfile -t hanzo:test .` passes; `gz302.yml`
      is correctly skipped in the container guard path
- [ ] Post-merge on real GZ302 hardware: `cat /etc/NetworkManager/conf.d/wifi-powersave.conf`
      confirms the drop-in is in place
- [ ] On first deploy, reconnect Wi-Fi (or reboot) before running
      `nmcli -f 802-11-wireless.powersave c show <conn>` — `[connection]`
      defaults are applied at connection-activation time; `state: reloaded`
      (SIGHUP) does not retroactively apply `wifi.powersave` to already-active
      connections.

### Extra Notes (optional)

The handler uses `state: reloaded` (SIGHUP) which reloads NM config files
without dropping connections. The power-save setting takes effect on the next
connection activation, so a manual reconnect or reboot is needed on first
deploy to observe the change.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`