### PR TITLE
chore(bootstrap): quote keepalive PID, pin ansible-core version

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -61,11 +61,6 @@ if uv tool list 2>/dev/null | grep -q "^ansible-core"; then
     log_info "ansible-core is already installed"
 else
     log_info "Installing ansible-core..."
-    # Pin ansible-core so a future breaking release never silently lands on a
-    # fresh provision. The ~= (compatible release) form lets 2.20.x bugfix and
-    # security patches flow through while still blocking 2.21+ breaking changes.
-    # The pin lives inline (not in group_vars/all.yml) because bootstrap.sh
-    # runs before Ansible is available to read vars.
     uv tool install 'ansible-core~=2.20.5'
 fi
 

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -39,7 +39,7 @@ sudo -v
 # Provisioning takes long enough for the sudo ticket to expire mid-run
 while true; do sudo -n true; sleep 50; done 2>/dev/null &
 SUDO_KEEPALIVE_PID=$!
-trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null' EXIT
+trap 'kill "$SUDO_KEEPALIVE_PID" 2>/dev/null' EXIT
 
 # ---------------------------------------------------------------------------
 # Step 2: Install uv (Astral's Python package manager)
@@ -61,7 +61,12 @@ if uv tool list 2>/dev/null | grep -q "^ansible-core"; then
     log_info "ansible-core is already installed"
 else
     log_info "Installing ansible-core..."
-    uv tool install ansible-core
+    # Pin ansible-core so a future breaking release never silently lands on a
+    # fresh provision. The ~= (compatible release) form lets 2.20.x bugfix and
+    # security patches flow through while still blocking 2.21+ breaking changes.
+    # The pin lives inline (not in group_vars/all.yml) because bootstrap.sh
+    # runs before Ansible is available to read vars.
+    uv tool install 'ansible-core~=2.20.5'
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issues

No related issue — routine hardening of `bin/bootstrap.sh`.

### Proposed Changes:

Two small hardening edits to `bin/bootstrap.sh`:

**1. Quote `$SUDO_KEEPALIVE_PID` in the cleanup trap**

Changed `kill $SUDO_KEEPALIVE_PID` to `kill "$SUDO_KEEPALIVE_PID"` in the `trap` line. PIDs are always numeric, so the unquoted form is functionally safe — there is no exploitation surface here. This is consistency hygiene: CLAUDE.md's Shell Scripts convention requires quoting all variable expansions (`"$VAR"`, not `$VAR`). Shellcheck has a dataflow carve-out for `kill $!` and does **not** enforce this case, so pre-commit passes identically before and after; the change is convention compliance only.

**2. Pin `ansible-core` to `~=2.20.5`**

The `uv tool install ansible-core` call now pins to `~=2.20.5` (the current latest stable release on PyPI, published 2026-04-21). Without a pin, a future breaking release of `ansible-core` (e.g. 2.21+) could land on a fresh provision and silently break the playbook. The PEP 440 compatible-release operator (`~=`) keeps 2.20.x bugfix and security patches flowing through automatically while still blocking 2.21+ breaking changes — preferable to a strict `==` pin that would freeze us on stale patches.

The pin lives inline in `bootstrap.sh` rather than in `group_vars/all.yml` because `bootstrap.sh` runs before Ansible is available to read vars. Extracting it to a sidecar shell-readable file for a single string would be YAGNI.

### Testing:

- `pre-commit run --all-files` — passes (shellcheck carve-out; no ansible-lint impact)
- `docker build -f tests/Containerfile -t hanzo:test .` — passes; `ansible-core 2.20.5` is installed and the playbook runs to completion

### Extra Notes (optional):

The quoting change is cosmetic/convention only. The ansible-core pin is the substantive hardening — it gives the provisioner a stable, known-good baseline while remaining open to patch releases.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`