### PR TITLE
security(packages): strengthen 1Password GPG key trust chain

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -80,16 +80,6 @@ security_aur_packages:
 # is in the building user's GPG keyring.
 onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
 
-# Recompute the two sha256 pins below on any trusted machine (uses an
-# ephemeral GNUPGHOME so the host keyring is untouched):
-#   curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
-#     | sha256sum                                  # => _sha256
-#   curl -fsSL -o /tmp/1p.asc \
-#     https://downloads.1password.com/linux/keys/1password.asc
-#   GNUPGHOME=$(mktemp -d) gpg --quiet --import /tmp/1p.asc \
-#     && gpg --export-options export-minimal \
-#            --export 3FEF9748469ADBE15DA7CA80AC2D62742012EA22 \
-#     | sha256sum                                  # => _export_sha256
 onepassword_gpg_key_url: "https://downloads.1password.com/linux/keys/1password.asc"
 onepassword_gpg_key_sha256: "f39e7dd9dedc581ced85732832f217e0de5860a3b80279b5af4bc7c6d8157bae"
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -80,6 +80,16 @@ security_aur_packages:
 # is in the building user's GPG keyring.
 onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
 
+# Recompute the two sha256 pins below on any trusted machine (uses an
+# ephemeral GNUPGHOME so the host keyring is untouched):
+#   curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+#     | sha256sum                                  # => _sha256
+#   curl -fsSL -o /tmp/1p.asc \
+#     https://downloads.1password.com/linux/keys/1password.asc
+#   GNUPGHOME=$(mktemp -d) gpg --quiet --import /tmp/1p.asc \
+#     && gpg --export-options export-minimal \
+#            --export 3FEF9748469ADBE15DA7CA80AC2D62742012EA22 \
+#     | sha256sum                                  # => _export_sha256
 onepassword_gpg_key_url: "https://downloads.1password.com/linux/keys/1password.asc"
 onepassword_gpg_key_sha256: "f39e7dd9dedc581ced85732832f217e0de5860a3b80279b5af4bc7c6d8157bae"
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -100,6 +100,15 @@ onepassword_gpg_key_sha256: "f39e7dd9dedc581ced85732832f217e0de5860a3b80279b5af4
 # the key material itself doesn't hash to this value.
 onepassword_gpg_key_export_sha256: "130fd029182686f52eb17304615d8377e7787a0d5b01a90db6b36de4e56fb05c"
 
+# Filesystem paths for the two GPG artifacts the packages role writes
+# under the shared ~/.cache/hanzo directory (created once by
+# playbook.yml's pre-task). Centralised here per project Rule #1
+# ("Data in group_vars/all.yml, logic in roles/") so the get_url dest,
+# the gpg --import argument, the gpg --output destination, and the
+# stat path all reference a single source of truth.
+onepassword_gpg_key_asc_path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.asc"
+onepassword_gpg_key_export_path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.gpg"
+
 # keyserver.ubuntu.com is more reliable than keys.openpgp.org for AUR
 # build flows. Used only as a fallback when the canonical URL above is
 # unreachable; the post-import verify pins the key material regardless

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -75,24 +75,14 @@ security_aur_packages:
   - 1password-cli
   - proton-vpn-gtk-app
 
-# Both 1password and 1password-cli PKGBUILDs pin validpgpkeys to this
-# fingerprint; makepkg refuses to build until the matching public key
-# is in the building user's GPG keyring.
+# Both-required GPG trust chain that seeds the user keyring so makepkg's
+# validpgpkeys check passes when building 1Password from the AUR.
 onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
-
 onepassword_gpg_key_url: "https://downloads.1password.com/linux/keys/1password.asc"
 onepassword_gpg_key_sha256: "f39e7dd9dedc581ced85732832f217e0de5860a3b80279b5af4bc7c6d8157bae"
-
-# Second pin on the binary export form (export-minimal, deterministic
-# across import paths) so a tampered key with a matching fingerprint
-# still fails the trust-chain assert in roles/packages.
 onepassword_gpg_key_export_sha256: "130fd029182686f52eb17304615d8377e7787a0d5b01a90db6b36de4e56fb05c"
-
 onepassword_gpg_key_asc_path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.asc"
 onepassword_gpg_key_export_path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.gpg"
-
-# keyserver.ubuntu.com is more reliable than keys.openpgp.org for AUR
-# build flows.
 onepassword_gpg_keyserver: "hkps://keyserver.ubuntu.com"
 
 # ---------------------------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -80,8 +80,30 @@ security_aur_packages:
 # is in the building user's GPG keyring.
 onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
 
+# Canonical URL for the AgileBits / 1Password signing key. Primary trust
+# anchor — preferred over keyserver retrieval because the file is served
+# from 1Password's own infrastructure over HTTPS and pinned by sha256.
+onepassword_gpg_key_url: "https://downloads.1password.com/linux/keys/1password.asc"
+
+# SHA256 of the canonical .asc file at onepassword_gpg_key_url. Pinned so
+# ansible.builtin.get_url refuses to import a tampered or rotated key
+# without an explicit hash update here. Rotation procedure documented in
+# the PR that introduced this pin.
+onepassword_gpg_key_sha256: "f39e7dd9dedc581ced85732832f217e0de5860a3b80279b5af4bc7c6d8157bae"
+
+# SHA256 of `gpg --export-options export-minimal --export <fpr>` for the
+# key above. export-minimal strips third-party signatures so the hash is
+# deterministic regardless of whether the key was imported from the
+# canonical URL or the keyserver fallback. Pinning the binary export
+# (in addition to the fingerprint and the .asc file) closes the trust
+# chain: even a keyring with a matching fingerprint will fail verify if
+# the key material itself doesn't hash to this value.
+onepassword_gpg_key_export_sha256: "130fd029182686f52eb17304615d8377e7787a0d5b01a90db6b36de4e56fb05c"
+
 # keyserver.ubuntu.com is more reliable than keys.openpgp.org for AUR
-# build flows.
+# build flows. Used only as a fallback when the canonical URL above is
+# unreachable; the post-import verify pins the key material regardless
+# of which path succeeded.
 onepassword_gpg_keyserver: "hkps://keyserver.ubuntu.com"
 
 # ---------------------------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -80,39 +80,19 @@ security_aur_packages:
 # is in the building user's GPG keyring.
 onepassword_gpg_key: "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
 
-# Canonical URL for the AgileBits / 1Password signing key. Primary trust
-# anchor — preferred over keyserver retrieval because the file is served
-# from 1Password's own infrastructure over HTTPS and pinned by sha256.
 onepassword_gpg_key_url: "https://downloads.1password.com/linux/keys/1password.asc"
-
-# SHA256 of the canonical .asc file at onepassword_gpg_key_url. Pinned so
-# ansible.builtin.get_url refuses to import a tampered or rotated key
-# without an explicit hash update here. Rotation procedure documented in
-# the PR that introduced this pin.
 onepassword_gpg_key_sha256: "f39e7dd9dedc581ced85732832f217e0de5860a3b80279b5af4bc7c6d8157bae"
 
-# SHA256 of `gpg --export-options export-minimal --export <fpr>` for the
-# key above. export-minimal strips third-party signatures so the hash is
-# deterministic regardless of whether the key was imported from the
-# canonical URL or the keyserver fallback. Pinning the binary export
-# (in addition to the fingerprint and the .asc file) closes the trust
-# chain: even a keyring with a matching fingerprint will fail verify if
-# the key material itself doesn't hash to this value.
+# Second pin on the binary export form (export-minimal, deterministic
+# across import paths) so a tampered key with a matching fingerprint
+# still fails the trust-chain assert in roles/packages.
 onepassword_gpg_key_export_sha256: "130fd029182686f52eb17304615d8377e7787a0d5b01a90db6b36de4e56fb05c"
 
-# Filesystem paths for the two GPG artifacts the packages role writes
-# under the shared ~/.cache/hanzo directory (created once by
-# playbook.yml's pre-task). Centralised here per project Rule #1
-# ("Data in group_vars/all.yml, logic in roles/") so the get_url dest,
-# the gpg --import argument, the gpg --output destination, and the
-# stat path all reference a single source of truth.
 onepassword_gpg_key_asc_path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.asc"
 onepassword_gpg_key_export_path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.gpg"
 
 # keyserver.ubuntu.com is more reliable than keys.openpgp.org for AUR
-# build flows. Used only as a fallback when the canonical URL above is
-# unreachable; the post-import verify pins the key material regardless
-# of which path succeeded.
+# build flows.
 onepassword_gpg_keyserver: "hkps://keyserver.ubuntu.com"
 
 # ---------------------------------------------------------------------------

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -68,8 +68,11 @@
 
 # Seed the user keyring with the AgileBits signing key (kewlfft.aur.aur
 # does not). Trust chain: sha256-pinned canonical URL (primary) with
-# keyserver --recv-keys as rescue; the export-sha256 assert below is
-# the load-bearing gate, not the fingerprint check. Every task sets
+# keyserver --recv-keys as rescue. Rescue exists so a 1Password CDN
+# outage does not block fresh installs; it cannot weaken the chain
+# because the export-sha256 assert below pins the key material itself,
+# so a rescue path serving a different key fails the play. That assert
+# (not the fingerprint check) is the load-bearing gate. Every task sets
 # check_mode: false so CI exercises every link under --check.
 - name: Check for AgileBits PGP signing key in user keyring
   ansible.builtin.command:

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -112,7 +112,7 @@
     - name: Fetch 1Password GPG key from canonical URL (sha256-pinned)
       ansible.builtin.get_url:
         url: "{{ onepassword_gpg_key_url }}"
-        dest: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.asc"
+        dest: "{{ onepassword_gpg_key_asc_path }}"
         checksum: "sha256:{{ onepassword_gpg_key_sha256 }}"
         mode: "0600"
       register: packages_onepassword_key_fetch
@@ -129,12 +129,29 @@
           - --batch
           - --no-tty
           - --import
-          - "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.asc"
-      register: packages_onepassword_key_import_primary
+          - "{{ onepassword_gpg_key_asc_path }}"
       changed_when: true
       check_mode: false
       become: false
   rescue:
+    # Surface the primary-path failure before falling back so a sha256
+    # mismatch (likely an upstream key rotation) is distinguishable in
+    # CI logs from a network error. Without this, both failure modes
+    # silently degrade to the keyserver path; the downstream
+    # export-sha256 assert still gates safety, but operators lose the
+    # "rotate the pin" signal that should trigger the documented
+    # rotation procedure.
+    - name: Log primary-path failure before keyserver fallback
+      ansible.builtin.debug:
+        msg: >-
+          Primary canonical-URL path failed; falling back to keyserver.
+          get_url result:
+          {{ packages_onepassword_key_fetch.msg
+             | default('no fetch error captured — likely a gpg --import failure') }}.
+          If the network is healthy, upstream may have rotated the key —
+          follow the rotation procedure in group_vars/all.yml rather than
+          relying on the rescue path indefinitely.
+
     - name: Fall back to keyserver for 1Password GPG key
       ansible.builtin.command:
         argv:
@@ -170,13 +187,16 @@
 
 # Export key material in deterministic minimal form so the sha256 is
 # stable across both import paths (export-minimal strips third-party
-# signatures that keyservers may attach).
+# signatures that keyservers may attach). changed_when is false because
+# the .gpg artifact is a transient verification scratch file overwritten
+# on every play (via --yes), not configuration drift; the meaningful
+# signal is the assert two tasks down, not this write.
 - name: Export 1Password GPG key material for verification
   ansible.builtin.command:
     argv:
       - gpg
       - --output
-      - "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.gpg"
+      - "{{ onepassword_gpg_key_export_path }}"
       - --yes
       - --export-options
       - export-minimal
@@ -188,7 +208,7 @@
 
 - name: Stat exported 1Password GPG key to compute sha256
   ansible.builtin.stat:
-    path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.gpg"
+    path: "{{ onepassword_gpg_key_export_path }}"
     checksum_algorithm: sha256
   register: packages_onepassword_key_export_stat
   check_mode: false

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -67,13 +67,11 @@
   become: false
 
 # Seed the user keyring with the AgileBits signing key (kewlfft.aur.aur
-# does not). Trust chain: sha256-pinned canonical URL (primary) with
-# keyserver --recv-keys as rescue. Rescue exists so a 1Password CDN
-# outage does not block fresh installs; it cannot weaken the chain
-# because the export-sha256 assert below pins the key material itself,
-# so a rescue path serving a different key fails the play. That assert
-# (not the fingerprint check) is the load-bearing gate. Every task sets
-# check_mode: false so CI exercises every link under --check.
+# does not). Trust chain: BOTH the sha256-pinned canonical URL AND the
+# keyserver --recv-keys must succeed (no fallback). The export-sha256
+# assert below pins the merged keyring state, so a divergent source
+# fails the play. Every task sets check_mode: false so CI exercises
+# every link under --check.
 - name: Check for AgileBits PGP signing key in user keyring
   ansible.builtin.command:
     argv:
@@ -86,7 +84,7 @@
   check_mode: false
   become: false
 
-- name: Import AgileBits PGP signing key (canonical URL with keyserver fallback)
+- name: Import AgileBits PGP signing key (canonical URL + keyserver, both required)
   when: packages_onepassword_key_check.rc != 0
   block:
     - name: Fetch 1Password GPG key from canonical URL (sha256-pinned)
@@ -113,21 +111,8 @@
       changed_when: true
       check_mode: false
       become: false
-  rescue:
-    # Make a sha256 mismatch (rotate the pin) distinguishable from a
-    # network failure in CI logs; both otherwise degrade silently.
-    - name: Log primary-path failure before keyserver fallback
-      ansible.builtin.debug:
-        msg: >-
-          Primary canonical-URL path failed; falling back to keyserver.
-          get_url result:
-          {{ packages_onepassword_key_fetch.msg
-             | default('no fetch error captured — likely a gpg --import failure') }}.
-          If the network is healthy, upstream may have rotated the key —
-          follow the rotation procedure in group_vars/all.yml rather than
-          relying on the rescue path indefinitely.
 
-    - name: Fall back to keyserver for 1Password GPG key
+    - name: Cross-verify 1Password GPG key from keyserver (must succeed)
       ansible.builtin.command:
         argv:
           - gpg
@@ -137,12 +122,12 @@
           - "{{ onepassword_gpg_keyserver }}"
           - --recv-keys
           - "{{ onepassword_gpg_key }}"
-      register: packages_onepassword_key_import_fallback
+      register: packages_onepassword_key_recv
       changed_when: true
       check_mode: false
       retries: 3
       delay: 5
-      until: packages_onepassword_key_import_fallback is succeeded
+      until: packages_onepassword_key_recv is succeeded
       become: false
 
 - name: Verify AgileBits PGP signing key is present after import

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -66,30 +66,11 @@
     use: paru
   become: false
 
-# 1password and 1password-cli AUR PKGBUILDs pin validpgpkeys to the
-# AgileBits signing key. makepkg verifies against the building user's
-# keyring; kewlfft.aur.aur does not seed it, so we import the key here.
-#
-# ~/.cache/hanzo is created once by playbook.yml's "Ensure Hanzo cache
-# directory exists" pre-task (mode 0700, check_mode: false); reused here
-# rather than recreated.
-#
-# Trust chain — enforced under --check so CI catches every break:
-#   1. Probe      — read keyring state. rc=0 present, rc=2 absent.
-#   2. Import     — primary: ansible.builtin.get_url fetches the canonical
-#                   .asc from 1Password (sha256-pinned) and gpg imports
-#                   from the local file. Fallback (rescue): the existing
-#                   keyserver --recv-keys path, kept as defense-in-depth
-#                   for when the canonical URL is unreachable.
-#   3. Verify     — assert (a) the imported fingerprint matches what we
-#                   asked for, and (b) the sha256 of the export-minimal
-#                   binary form matches the pinned key material. Pinning
-#                   the export catches a tampered key whose displayed
-#                   fingerprint happens to match — fingerprint-only is a
-#                   tautology since `--list-keys <fpr>` filters on the
-#                   value we're asking about.
-#   4. Install    — kewlfft.aur.aur invokes paru → makepkg → validpgpkeys
-#                   cross-check. Only exercised in real mode.
+# Seed the user keyring with the AgileBits signing key (kewlfft.aur.aur
+# does not). Trust chain: sha256-pinned canonical URL (primary) with
+# keyserver --recv-keys as rescue; the export-sha256 assert below is
+# the load-bearing gate, not the fingerprint check. Every task sets
+# check_mode: false so CI exercises every link under --check.
 - name: Check for AgileBits PGP signing key in user keyring
   ansible.builtin.command:
     argv:
@@ -102,10 +83,6 @@
   check_mode: false
   become: false
 
-# Primary path: fetch the canonical .asc from 1Password (sha256-pinned)
-# and import locally. Fallback (rescue): the keyserver --recv-keys path.
-# Both produce the same imported keyring state; the unconditional verify
-# tasks below are the single point of truth.
 - name: Import AgileBits PGP signing key (canonical URL with keyserver fallback)
   when: packages_onepassword_key_check.rc != 0
   block:
@@ -134,13 +111,8 @@
       check_mode: false
       become: false
   rescue:
-    # Surface the primary-path failure before falling back so a sha256
-    # mismatch (likely an upstream key rotation) is distinguishable in
-    # CI logs from a network error. Without this, both failure modes
-    # silently degrade to the keyserver path; the downstream
-    # export-sha256 assert still gates safety, but operators lose the
-    # "rotate the pin" signal that should trigger the documented
-    # rotation procedure.
+    # Make a sha256 mismatch (rotate the pin) distinguishable from a
+    # network failure in CI logs; both otherwise degrade silently.
     - name: Log primary-path failure before keyserver fallback
       ansible.builtin.debug:
         msg: >-
@@ -185,12 +157,8 @@
   check_mode: false
   become: false
 
-# Export key material in deterministic minimal form so the sha256 is
-# stable across both import paths (export-minimal strips third-party
-# signatures that keyservers may attach). changed_when is false because
-# the .gpg artifact is a transient verification scratch file overwritten
-# on every play (via --yes), not configuration drift; the meaningful
-# signal is the assert two tasks down, not this write.
+# export-minimal strips third-party signatures so the binary hash is
+# deterministic across both import paths.
 - name: Export 1Password GPG key material for verification
   ansible.builtin.command:
     argv:

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -70,15 +70,26 @@
 # AgileBits signing key. makepkg verifies against the building user's
 # keyring; kewlfft.aur.aur does not seed it, so we import the key here.
 #
+# ~/.cache/hanzo is created once by playbook.yml's "Ensure Hanzo cache
+# directory exists" pre-task (mode 0700, check_mode: false); reused here
+# rather than recreated.
+#
 # Trust chain — enforced under --check so CI catches every break:
-#   1. Probe   — read keyring state. rc=0 present, rc=2 absent.
-#   2. Import  — fetch from keyserver when absent. Retries 3x on
-#                transient network failure.
-#   3. Verify  — assert the imported fingerprint matches what we asked
-#                for. Catches a misbehaving keyserver or a silently
-#                failed import before any package is built.
-#   4. Install — kewlfft.aur.aur invokes paru → makepkg → validpgpkeys
-#                cross-check. Only exercised in real mode.
+#   1. Probe      — read keyring state. rc=0 present, rc=2 absent.
+#   2. Import     — primary: ansible.builtin.get_url fetches the canonical
+#                   .asc from 1Password (sha256-pinned) and gpg imports
+#                   from the local file. Fallback (rescue): the existing
+#                   keyserver --recv-keys path, kept as defense-in-depth
+#                   for when the canonical URL is unreachable.
+#   3. Verify     — assert (a) the imported fingerprint matches what we
+#                   asked for, and (b) the sha256 of the export-minimal
+#                   binary form matches the pinned key material. Pinning
+#                   the export catches a tampered key whose displayed
+#                   fingerprint happens to match — fingerprint-only is a
+#                   tautology since `--list-keys <fpr>` filters on the
+#                   value we're asking about.
+#   4. Install    — kewlfft.aur.aur invokes paru → makepkg → validpgpkeys
+#                   cross-check. Only exercised in real mode.
 - name: Check for AgileBits PGP signing key in user keyring
   ansible.builtin.command:
     argv:
@@ -91,22 +102,56 @@
   check_mode: false
   become: false
 
-- name: Import AgileBits PGP signing key
-  ansible.builtin.command:
-    argv:
-      - gpg
-      - --keyserver
-      - "{{ onepassword_gpg_keyserver }}"
-      - --recv-keys
-      - "{{ onepassword_gpg_key }}"
-  register: packages_onepassword_key_import
+# Primary path: fetch the canonical .asc from 1Password (sha256-pinned)
+# and import locally. Fallback (rescue): the keyserver --recv-keys path.
+# Both produce the same imported keyring state; the unconditional verify
+# tasks below are the single point of truth.
+- name: Import AgileBits PGP signing key (canonical URL with keyserver fallback)
   when: packages_onepassword_key_check.rc != 0
-  changed_when: true
-  check_mode: false
-  retries: 3
-  delay: 5
-  until: packages_onepassword_key_import is succeeded
-  become: false
+  block:
+    - name: Fetch 1Password GPG key from canonical URL (sha256-pinned)
+      ansible.builtin.get_url:
+        url: "{{ onepassword_gpg_key_url }}"
+        dest: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.asc"
+        checksum: "sha256:{{ onepassword_gpg_key_sha256 }}"
+        mode: "0600"
+      register: packages_onepassword_key_fetch
+      check_mode: false
+      retries: 3
+      delay: 5
+      until: packages_onepassword_key_fetch is succeeded
+      become: false
+
+    - name: Import 1Password GPG key from canonical .asc file
+      ansible.builtin.command:
+        argv:
+          - gpg
+          - --batch
+          - --no-tty
+          - --import
+          - "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.asc"
+      register: packages_onepassword_key_import_primary
+      changed_when: true
+      check_mode: false
+      become: false
+  rescue:
+    - name: Fall back to keyserver for 1Password GPG key
+      ansible.builtin.command:
+        argv:
+          - gpg
+          - --batch
+          - --no-tty
+          - --keyserver
+          - "{{ onepassword_gpg_keyserver }}"
+          - --recv-keys
+          - "{{ onepassword_gpg_key }}"
+      register: packages_onepassword_key_import_fallback
+      changed_when: true
+      check_mode: false
+      retries: 3
+      delay: 5
+      until: packages_onepassword_key_import_fallback is succeeded
+      become: false
 
 - name: Verify AgileBits PGP signing key is present after import
   ansible.builtin.command:
@@ -121,6 +166,45 @@
     packages_onepassword_key_verify.rc != 0
     or onepassword_gpg_key not in packages_onepassword_key_verify.stdout
   check_mode: false
+  become: false
+
+# Export key material in deterministic minimal form so the sha256 is
+# stable across both import paths (export-minimal strips third-party
+# signatures that keyservers may attach).
+- name: Export 1Password GPG key material for verification
+  ansible.builtin.command:
+    argv:
+      - gpg
+      - --output
+      - "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.gpg"
+      - --yes
+      - --export-options
+      - export-minimal
+      - --export
+      - "{{ onepassword_gpg_key }}"
+  changed_when: false
+  check_mode: false
+  become: false
+
+- name: Stat exported 1Password GPG key to compute sha256
+  ansible.builtin.stat:
+    path: "{{ ansible_facts.env.HOME }}/.cache/hanzo/1password.gpg"
+    checksum_algorithm: sha256
+  register: packages_onepassword_key_export_stat
+  check_mode: false
+  become: false
+
+- name: Assert exported 1Password GPG key material matches pinned sha256
+  ansible.builtin.assert:
+    that:
+      - packages_onepassword_key_export_stat.stat.checksum == onepassword_gpg_key_export_sha256
+    fail_msg: >-
+      Exported 1Password GPG key sha256
+      ({{ packages_onepassword_key_export_stat.stat.checksum }})
+      does not match pinned value ({{ onepassword_gpg_key_export_sha256 }}).
+      Either the key has rotated upstream (update group_vars/all.yml per
+      the documented rotation procedure) or the imported key has been
+      tampered with — investigate before proceeding.
   become: false
 
 - name: Install security AUR packages


### PR DESCRIPTION
### Related Issues

No dedicated issue filed — this is a self-contained security hardening task (PR D in the supply-chain series).

### Proposed Changes

The previous import path had two weaknesses:

1. **Single keyserver SPOF** — `hkps://keyserver.ubuntu.com` was the only source. Any downtime or poisoning blocked or silently degraded provisioning.
2. **Fingerprint-only verify is a tautology** — `gpg --list-keys <fpr>` filters on the very value we're asserting; it cannot catch a key whose fingerprint matches but whose material was tampered.

This PR closes both gaps with a **both-required** trust model — both the canonical URL and the keyserver must succeed on every fresh install, with no silent fallback:

- **Canonical URL fetch**: `ansible.builtin.get_url` downloads `https://downloads.1password.com/linux/keys/1password.asc` with a pinned `sha256` checksum (`onepassword_gpg_key_sha256` in `group_vars/all.yml`). A sha256 mismatch fails the play hard.
- **Canonical .asc import**: `gpg --batch --no-tty --import` of the verified `.asc` lands the key in the user keyring.
- **Cross-verify from keyserver (must succeed)**: `gpg --recv-keys` against `hkps://keyserver.ubuntu.com`. A non-zero result fails the play.
- **Post-import material verify**: `gpg --export-options export-minimal --export <fpr>` produces a deterministic binary export (no third-party signatures), `ansible.builtin.stat` checksums it, and `ansible.builtin.assert` compares against `onepassword_gpg_key_export_sha256`. This pins the **merged keyring state**, so a divergent source — whichever one — fails here.

Trade-off: the keyserver becomes a hard dependency on every fresh install, not a soft rescue. Accepted on the basis that 100% trust posture matters more than provisioning-time availability for a single-laptop home configuration.

All five new `group_vars` variables follow Rule #1 (data in `group_vars/all.yml`, referenced by name in tasks): `onepassword_gpg_key_url`, `onepassword_gpg_key_sha256`, `onepassword_gpg_key_export_sha256`, `onepassword_gpg_key_asc_path`, `onepassword_gpg_key_export_path`.

### Testing

- `pre-commit run --all-files` — ansible-lint, shellcheck, generic hooks
- `docker build -f tests/Containerfile -t hanzo:test .` — full `--check --diff` run inside CachyOS container exercises every link of the trust chain (each task carries `check_mode: false`). PLAY RECAP: `ok=41 changed=26 failed=0 rescued=0`.

### Key Rotation Procedure

When 1Password rotates their signing key, both pinned sha256 values must be recomputed on a trusted machine and committed to `group_vars/all.yml`.

If the previously-pinned key is already in the user keyring (typical case — Hanzo previously ran on this machine), first delete it so the probe fires on the next run:

```bash
gpg --delete-key 3FEF9748469ADBE15DA7CA80AC2D62742012EA22
```

Then recompute the two pins:

```bash
# 1. onepassword_gpg_key_sha256 (the .asc file)
curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | sha256sum
# => f39e7dd9dedc581ced85732832f217e0de5860a3b80279b5af4bc7c6d8157bae  -

# 2. onepassword_gpg_key_export_sha256 (export-minimal binary,
#    ephemeral GNUPGHOME so the host keyring is untouched)
curl -fsSL -o /tmp/1p.asc https://downloads.1password.com/linux/keys/1password.asc
GNUPGHOME=$(mktemp -d) gpg --quiet --import /tmp/1p.asc \
  && gpg --export-options export-minimal \
         --export 3FEF9748469ADBE15DA7CA80AC2D62742012EA22 \
  | sha256sum
# => 130fd029182686f52eb17304615d8377e7787a0d5b01a90db6b36de4e56fb05c  -
```

If 1Password rotates to a new primary key (different fingerprint), update `onepassword_gpg_key` in `group_vars/all.yml` as well.

Verify in CI before merging:

```bash
pre-commit run --all-files
docker build -f tests/Containerfile -t hanzo:test .
```

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`
