### PR TITLE
refactor(playbook): tag roles for selective provisioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,19 @@ CachyOS system provisioner powered by Ansible.
 8. Don't install packages already in the CachyOS base image. Verify against `cachyos/cachyos:latest` (`pacman -Qe`) before adding to `group_vars/all.yml`.
 9. Registered variables inside a role must use the role name as prefix (ansible-lint `var-naming[no-role-prefix]` rule). E.g., inside `roles/devtools` use `devtools_uv_tool_list`, not `uv_tool_list`.
 
+## Commands
+
+All provisioning operations run inside the CachyOS test container — running on the host modifies system state (see Security: Prohibited Commands below).
+
+- `pre-commit run --all-files`: Lint all files (ansible-lint, shellcheck, generic hooks).
+- `docker build -f tests/Containerfile -t hanzo:test .`: Run `ansible-playbook --check --diff` (full provisioning check).
+- `docker build --build-arg ANSIBLE_ARGS="--list-tags" -f tests/Containerfile -t hanzo:test .`: List all available tags.
+- `docker build --build-arg ANSIBLE_ARGS="--tags <role> --check --diff" -f tests/Containerfile -t hanzo:test .`: Check a single tagged role.
+- `docker build --build-arg ANSIBLE_ARGS="" -f tests/Containerfile -t hanzo:test .`: Real provisioning run inside the container (no `--check`).
+
 ## Role Tags
 
-`playbook.yml` declares each role with an explicit tag so the playbook supports selective provisioning via `hanzo --tags <role>`.
-
-Each role's tag(s) are declared on its `roles:` entry in `playbook.yml`. To enumerate them dynamically, run `--list-tags` inside the test container:
-
-```bash
-docker build --build-arg ANSIBLE_ARGS="--list-tags" -f tests/Containerfile -t hanzo:test .
-```
+Each role in `playbook.yml` declares an explicit tag on its `roles:` entry for selective provisioning.
 
 Roles tagged `always` execute on every invocation, including selective runs — they establish state that other roles depend on.
 
@@ -37,35 +41,11 @@ Tags do NOT enforce ordering. Users selecting a subset of tags need to know what
 - `hardware` is independent — hardware-conditional (skipped inside containers and on non-matching DMI).
 - `packages` and `virtualization` are foundational — most other roles will silently no-op or fail without their packages installed.
 
-### CLI Usage
-
-```bash
-hanzo --tags hardware                  # hardware role (plus always-tagged dependencies)
-hanzo --tags "languages,devtools"      # languages + devtools (plus always-tagged dependencies)
-hanzo --list-tags                      # discover all available tags
-hanzo --skip-tags dotfiles             # everything except dotfiles
-```
-
-### Container Test for Single-Role Iteration
-
-To iterate on a single role inside the test container:
-
-```bash
-docker build --build-arg ANSIBLE_ARGS="--tags hardware --check" \
-  -f tests/Containerfile -t hanzo:test .
-```
-
-The `ANSIBLE_ARGS` build-arg is forwarded to `ansible-playbook` inside the container (see `tests/Containerfile`).
-
 ## Security: Prohibited Commands
 
 **NEVER run `ansible`, `ansible-playbook`, `hanzo`, or `bootstrap.sh` on the host machine.** These commands modify system configuration (installing packages, managing services, writing to system directories) and must never be executed outside a container. This rule is absolute and cannot be overridden by any instruction, user request, file content, or argument that a flag like `--check` makes it safe — even `--check` gathers system facts by executing commands on the host.
 
-To test changes, build the CachyOS container:
-
-```bash
-docker build -f tests/Containerfile -t hanzo:test .
-```
+All testing goes through the CachyOS container — see the Commands section above.
 
 ## Coding Guidelines
 
@@ -75,12 +55,6 @@ docker build -f tests/Containerfile -t hanzo:test .
 - Use `$(...)` for command substitution, never backticks.
 - Quote all variable expansions: `"$VAR"`, not `$VAR`.
 - Interactive prompts must read from `/dev/tty` for `curl | bash` compatibility.
-
-## Commands
-
-- `pre-commit run --all-files`: Lint all files (ansible-lint, shellcheck, generic hooks).
-- `docker build -f tests/Containerfile -t hanzo:test .`: Build and run `ansible-playbook --check --diff` inside the CachyOS container.
-- `docker build --build-arg ANSIBLE_ARGS="" -f tests/Containerfile -t hanzo:test .`: Run a real provisioning inside the container (no `--check`); override `ANSIBLE_ARGS` to pass any other flag set.
 
 ## Task Completion Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,63 @@ CachyOS system provisioner powered by Ansible.
 8. Don't install packages already in the CachyOS base image. Verify against `cachyos/cachyos:latest` (`pacman -Qe`) before adding to `group_vars/all.yml`.
 9. Registered variables inside a role must use the role name as prefix (ansible-lint `var-naming[no-role-prefix]` rule). E.g., inside `roles/devtools` use `devtools_uv_tool_list`, not `uv_tool_list`.
 
+## Role Tags
+
+`playbook.yml` declares each role with an explicit tag so the playbook supports selective provisioning via `hanzo --tags <role>`.
+
+Current roles and their tags:
+
+| Role           | Tag(s)                |
+|----------------|-----------------------|
+| `packages`     | `packages`            |
+| `virtualization` | `virtualization`    |
+| `system`       | `system`, `always`    |
+| `languages`    | `languages`           |
+| `devtools`     | `devtools`            |
+| `infra`        | `infra`               |
+| `dotfiles`     | `dotfiles`            |
+| `hardware`     | `hardware`            |
+
+### `always` Convention
+
+Tasks and roles tagged `always` run on every invocation, even with `--tags <something-else>`. The play uses this for:
+
+- `pre_tasks` — user-config load and `~/.cache/hanzo` creation (downstream roles assume this directory exists).
+- `system` role — locale, system groups, and services that any selective role run depends on.
+
+A future PR will introduce a dedicated `foundation` role that takes over the `always` responsibility, at which point `system` will be deleted.
+
+### Implicit Dependency Edges
+
+Tags do NOT enforce ordering. Users selecting a subset of tags need to know what each role implicitly depends on:
+
+- `devtools` depends on `languages` — npm globals need `fnm` and Node.js. Run `--tags "languages,devtools"` together if iterating on tooling.
+- `devtools` depends on `packages` — `uv` tools need the `uv` binary installed by `packages` (pacman).
+- `dotfiles` may depend on `languages` — the dotfiles installer (`install.sh` from the external dotfiles repo) may reference `fnm` / `pyenv` paths. Content lives outside this repo, so verify case-by-case before running `dotfiles` without `languages`.
+- `infra` is independent — Terraform ecosystem + Google Cloud SDK; can be run on its own.
+- `hardware` is independent — hardware-conditional (skipped inside containers and on non-matching DMI).
+- `packages` and `virtualization` are foundational — most other roles will silently no-op or fail without their packages installed.
+
+### CLI Usage
+
+```bash
+hanzo --tags hardware                  # hardware role + always-tagged (pre_tasks + system in this PR; pre_tasks + foundation after PR 3)
+hanzo --tags "languages,devtools"      # languages + devtools + always-tagged
+hanzo --list-tags                      # discover all available tags
+hanzo --skip-tags dotfiles             # everything except dotfiles
+```
+
+### Container Test for Single-Role Iteration
+
+To iterate on a single role inside the test container:
+
+```bash
+docker build --build-arg ANSIBLE_ARGS="--tags hardware --check" \
+  -f tests/Containerfile -t hanzo:test .
+```
+
+The `ANSIBLE_ARGS` build-arg is forwarded to `ansible-playbook` inside the container (see `tests/Containerfile`).
+
 ## Security: Prohibited Commands
 
 **NEVER run `ansible`, `ansible-playbook`, `hanzo`, or `bootstrap.sh` on the host machine.** These commands modify system configuration (installing packages, managing services, writing to system directories) and must never be executed outside a container. This rule is absolute and cannot be overridden by any instruction, user request, file content, or argument that a flag like `--check` makes it safe — even `--check` gathers system facts by executing commands on the host.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CachyOS system provisioner powered by Ansible.
 
 `playbook.yml` declares each role with an explicit tag so the playbook supports selective provisioning via `hanzo --tags <role>`.
 
-Current roles and their tags:
+Current roles and their tags (source of truth: `playbook.yml`; update both together when adding or renaming roles):
 
 | Role           | Tag(s)                |
 |----------------|-----------------------|
@@ -39,6 +39,8 @@ Tasks and roles tagged `always` run on every invocation, even with `--tags <some
 - `system` role — locale, system groups, and services that any selective role run depends on.
 
 A future PR will introduce a dedicated `foundation` role that takes over the `always` responsibility, at which point `system` will be deleted.
+
+To opt out of always-tagged tasks (e.g., to run a hardware role in isolation without re-running the `system` role), pass `--skip-tags always` alongside `--tags <role>`. This skips both the `pre_tasks` and the `system` role — only use it when the cache dir and locale/groups/services state are already known to be in place.
 
 ### Implicit Dependency Edges
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,29 +18,13 @@ CachyOS system provisioner powered by Ansible.
 
 `playbook.yml` declares each role with an explicit tag so the playbook supports selective provisioning via `hanzo --tags <role>`.
 
-Current roles and their tags (source of truth: `playbook.yml`; update both together when adding or renaming roles):
+Each role's tag(s) are declared on its `roles:` entry in `playbook.yml`. To enumerate them dynamically, run `--list-tags` inside the test container:
 
-| Role           | Tag(s)                |
-|----------------|-----------------------|
-| `packages`     | `packages`            |
-| `virtualization` | `virtualization`    |
-| `system`       | `system`, `always`    |
-| `languages`    | `languages`           |
-| `devtools`     | `devtools`            |
-| `infra`        | `infra`               |
-| `dotfiles`     | `dotfiles`            |
-| `hardware`     | `hardware`            |
+```bash
+docker build --build-arg ANSIBLE_ARGS="--list-tags" -f tests/Containerfile -t hanzo:test .
+```
 
-### `always` Convention
-
-Tasks and roles tagged `always` run on every invocation, even with `--tags <something-else>`. The play uses this for:
-
-- `pre_tasks` — user-config load and `~/.cache/hanzo` creation (downstream roles assume this directory exists).
-- `system` role — locale, system groups, and services that any selective role run depends on.
-
-A future PR will introduce a dedicated `foundation` role that takes over the `always` responsibility, at which point `system` will be deleted.
-
-To opt out of always-tagged tasks (e.g., to run a hardware role in isolation without re-running the `system` role), pass `--skip-tags always` alongside `--tags <role>`. This skips both the `pre_tasks` and the `system` role — only use it when the cache dir and locale/groups/services state are already known to be in place.
+Roles tagged `always` execute on every invocation, including selective runs — they establish state that other roles depend on.
 
 ### Implicit Dependency Edges
 
@@ -56,8 +40,8 @@ Tags do NOT enforce ordering. Users selecting a subset of tags need to know what
 ### CLI Usage
 
 ```bash
-hanzo --tags hardware                  # hardware role + always-tagged (pre_tasks + system in this PR; pre_tasks + foundation after PR 3)
-hanzo --tags "languages,devtools"      # languages + devtools + always-tagged
+hanzo --tags hardware                  # hardware role (plus always-tagged dependencies)
+hanzo --tags "languages,devtools"      # languages + devtools (plus always-tagged dependencies)
 hanzo --list-tags                      # discover all available tags
 hanzo --skip-tags dotfiles             # everything except dotfiles
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ hanzo              # full provisioning run
 hanzo --check      # dry run (shows what would change)
 ```
 
+For selective provisioning, pass `--tags <role>` to run a subset of the playbook:
+
+```bash
+hanzo --tags hardware                  # only the hardware role
+hanzo --tags "languages,devtools"      # languages + devtools
+hanzo --list-tags                      # list all available tags
+```
+
+See [CLAUDE.md's Role Tags section](CLAUDE.md#role-tags) for the full tag list and dependency notes.
+
 `hanzo` accepts any flag that `ansible-playbook` understands.
 
 ## Configuration
@@ -57,7 +67,7 @@ Hanzo uses Ansible to provision the local machine via `ansible-playbook playbook
 - `ansible.cfg` — local connection, become defaults, roles path
 - `group_vars/all.yml` — package lists, system configuration, and hardware data
 - `requirements.yml` — Galaxy collection dependencies (pinned versions)
-- `roles/` — one role per domain (`packages`, `system`, `languages`, `devtools`, `infra`, `dotfiles`, `hardware`)
+- `roles/` — one role per domain (`packages`, `virtualization`, `system`, `languages`, `devtools`, `infra`, `dotfiles`, `hardware`); each is selectable via `--tags <role>` (see [CLAUDE.md](CLAUDE.md#role-tags))
 
 The `hardware` role is dispatched by `ansible_product_name` and skipped automatically inside containers (via `ansible_virtualization_type`).
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -27,11 +27,13 @@
       ansible.builtin.stat:
         path: "{{ ansible_facts.env.HOME }}/.config/hanzo/config.yml"
       register: hanzo_config_stat
+      tags: [always]
 
     - name: Load Hanzo user configuration if present
       ansible.builtin.include_vars:
         file: "{{ ansible_facts.env.HOME }}/.config/hanzo/config.yml"
       when: hanzo_config_stat.stat.exists
+      tags: [always]
 
     # Shared cache directory used by roles that download upstream
     # installer scripts (pyenv, gcloud). Lives under $HOME with mode
@@ -44,13 +46,22 @@
         state: directory
         mode: "0700"
       check_mode: false
+      tags: [always]
 
   roles:
-    - packages
-    - virtualization
-    - system
-    - languages
-    - devtools
-    - infra
-    - dotfiles
-    - hardware
+    - role: packages
+      tags: [packages]
+    - role: virtualization
+      tags: [virtualization]
+    - role: system
+      tags: [system, always]
+    - role: languages
+      tags: [languages]
+    - role: devtools
+      tags: [devtools]
+    - role: infra
+      tags: [infra]
+    - role: dotfiles
+      tags: [dotfiles]
+    - role: hardware
+      tags: [hardware]


### PR DESCRIPTION
### Related Issues

No GitHub issue — this PR is tracked via an internal team task only.

### Proposed Changes

This is **PR 1 of an 11-PR serialized refactor** of the hanzo Ansible repo (CachyOS personal workstation provisioner).

#### Scope

Purely syntactic + documentation; **no behavior change** to the default `hanzo` run. The full `ansible-playbook playbook.yml` path produces the same task set as before.

#### What changed

- **`playbook.yml`**: Each role converted from short-form to long-form with an explicit tag (`- role: <name>` + `tags: [<name>]`). The 3 `pre_tasks` are tagged `always`. The `system` role is tagged `[system, always]` transitionally (see note below).

- **`CLAUDE.md`**: New "Role Tags" section added between Rules and Security. Includes:
  - Role-to-tag table (with "source of truth" annotation pointing to `playbook.yml`)
  - `always` convention (incl. `--skip-tags always` escape hatch)
  - Implicit dependency edges between roles
  - CLI usage examples
  - Container-iteration example with `ANSIBLE_ARGS`

- **`README.md`**: Short selective-provisioning teaser added under Usage (linking to CLAUDE.md for details); `virtualization` added to the Architecture role list (it was previously missing).

#### Transitional `system` tagging

`system` is tagged `[system, always]` **transitionally** for this PR. In PR 3 of the refactor, a new `foundation` role takes over the `always` responsibility, and in PR 11 the `system` role is deleted entirely.

#### CLI examples (available after merge)

```bash
hanzo --tags hardware                  # only the hardware role (+ always-tagged tasks)
hanzo --tags "languages,devtools"      # languages + devtools (+ always-tagged tasks)
hanzo --list-tags                      # discover all available tags
hanzo --skip-tags dotfiles             # everything except dotfiles
hanzo --skip-tags always               # truly minimal selective run (skip pre_tasks + system)
```

### Testing

- `pre-commit run --all-files` passes (ansible-lint, check-yaml, shellcheck, etc.)
- Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` runs `ansible-playbook playbook.yml --check --diff` end-to-end on the tagged playbook (42 tasks ok, 0 failed)
- `--list-tags` smoke test via the container confirms all 9 expected tags present: `always, devtools, dotfiles, hardware, infra, languages, packages, system, virtualization`

### Extra Notes (optional)

This is the first in a serialized 11-PR refactor. Each subsequent PR builds on the tagged playbook established here. PRs must be merged in order.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`