### PR TITLE
refactor(roles): extract foundation role for cache, locale, baseline CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ CachyOS system provisioner powered by Ansible.
 3. `ansible.builtin.shell` / `ansible.builtin.command` are the escape hatch. Use only when no module exists (e.g., paru via `kewlfft.aur.aur`, fnm version manager). Always include `name:` and either an explicit `changed_when:` clause or a `creates:` argument so ansible-lint's `no-changed-when` rule is satisfied without disabling it.
 4. Explicit `become:` on every task. The playbook default is `become: false`. Every task declares `become: true` (system operations: package installs, service management, config writes) or `become: false` (user-space: paru, dotfiles, language version managers).
 5. Hardware detection belongs in `roles/hardware/tasks/main.yml`. The `when:` clause ANDs `ansible_facts['product_name']` against `ansible_facts['virtualization_type']` so the role is skipped inside Docker / Podman / generic containers. This replaces the previous `SKIP_HARDWARE_CHECK` env var — moving the check into the playbook keeps the policy in one place and prevents host-DMI bleed-through in container tests.
-6. One role per domain. `packages` for package installation, `system` for groups/services/locale, etc.
+6. One role per domain. `foundation` for substrate (cache, locale, baseline CLI), `packages` for package installation, `system` for groups/services, etc.
 7. Every task needs `name:`. Descriptive names appear in Ansible output: "Install base development packages", not "packages". Keep Jinja expressions at the end of task names (ansible-lint `name[template]` rule).
 8. Don't install packages already in the CachyOS base image. Verify against `cachyos/cachyos:latest` (`pacman -Qe`) before adding to `group_vars/all.yml`.
 9. Registered variables inside a role must use the role name as prefix (ansible-lint `var-naming[no-role-prefix]` rule). E.g., inside `roles/devtools` use `devtools_uv_tool_list`, not `uv_tool_list`.
@@ -34,8 +34,8 @@ Roles tagged `always` execute on every invocation, including selective runs — 
 
 Tags do NOT enforce ordering. Users selecting a subset of tags need to know what each role implicitly depends on:
 
+- `foundation` is the substrate — creates `~/.cache/hanzo`, writes `/etc/locale.conf`, and installs baseline CLI packages with `update_cache: true`. Tagged `[foundation, always]`; runs first on every invocation. Implicit dependency target of `trust` (GPG cache paths), `languages` (pyenv installer), and `infra` (gcloud installer).
 - `devtools` depends on `languages` — npm globals need `fnm` and Node.js. Run `--tags "languages,devtools"` together if iterating on tooling.
-- `devtools` depends on `packages` — `uv` tools need the `uv` binary installed by `packages` (pacman).
 - `dotfiles` may depend on `languages` — the dotfiles installer (`install.sh` from the external dotfiles repo) may reference `fnm` / `pyenv` paths. Content lives outside this repo, so verify case-by-case before running `dotfiles` without `languages`.
 - `trust` is independent — seeds the user GPG keyring under a dual-source verification pattern; safe to run on its own.
 - `security` depends on `trust` — `paru`'s makepkg `validpgpkeys` check for `1password` needs the AgileBits GPG key in the user keyring. `trust` is tagged `always` so any `--tags security` run imports the key first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ CachyOS system provisioner powered by Ansible.
 3. `ansible.builtin.shell` / `ansible.builtin.command` are the escape hatch. Use only when no module exists (e.g., paru via `kewlfft.aur.aur`, fnm version manager). Always include `name:` and either an explicit `changed_when:` clause or a `creates:` argument so ansible-lint's `no-changed-when` rule is satisfied without disabling it.
 4. Explicit `become:` on every task. The playbook default is `become: false`. Every task declares `become: true` (system operations: package installs, service management, config writes) or `become: false` (user-space: paru, dotfiles, language version managers).
 5. Hardware detection belongs in `roles/hardware/tasks/main.yml`. The `when:` clause ANDs `ansible_facts['product_name']` against `ansible_facts['virtualization_type']` so the role is skipped inside Docker / Podman / generic containers. This replaces the previous `SKIP_HARDWARE_CHECK` env var — moving the check into the playbook keeps the policy in one place and prevents host-DMI bleed-through in container tests.
-6. One role per domain. `foundation` for substrate (cache, locale, baseline CLI), `packages` for package installation, `system` for groups/services, etc.
+6. One role per domain. Every role must declare a tag.
 7. Every task needs `name:`. Descriptive names appear in Ansible output: "Install base development packages", not "packages". Keep Jinja expressions at the end of task names (ansible-lint `name[template]` rule).
 8. Don't install packages already in the CachyOS base image. Verify against `cachyos/cachyos:latest` (`pacman -Qe`) before adding to `group_vars/all.yml`.
 9. Registered variables inside a role must use the role name as prefix (ansible-lint `var-naming[no-role-prefix]` rule). E.g., inside `roles/devtools` use `devtools_uv_tool_list`, not `uv_tool_list`.
@@ -29,19 +29,6 @@ All provisioning operations run inside the CachyOS test container — running on
 Each role in `playbook.yml` declares an explicit tag on its `roles:` entry for selective provisioning.
 
 Roles tagged `always` execute on every invocation, including selective runs — they establish state that other roles depend on.
-
-### Implicit Dependency Edges
-
-Tags do NOT enforce ordering. Users selecting a subset of tags need to know what each role implicitly depends on:
-
-- `foundation` is the substrate — creates `~/.cache/hanzo`, writes `/etc/locale.conf`, and installs baseline CLI packages with `update_cache: true`. Tagged `[foundation, always]`; runs first on every invocation. Implicit dependency target of `trust` (GPG cache paths), `languages` (pyenv installer), and `infra` (gcloud installer).
-- `devtools` depends on `languages` — npm globals need `fnm` and Node.js. Run `--tags "languages,devtools"` together if iterating on tooling.
-- `dotfiles` may depend on `languages` — the dotfiles installer (`install.sh` from the external dotfiles repo) may reference `fnm` / `pyenv` paths. Content lives outside this repo, so verify case-by-case before running `dotfiles` without `languages`.
-- `trust` is independent — seeds the user GPG keyring under a dual-source verification pattern; safe to run on its own.
-- `security` depends on `trust` — `paru`'s makepkg `validpgpkeys` check for `1password` needs the AgileBits GPG key in the user keyring. `trust` is tagged `always` so any `--tags security` run imports the key first.
-- `infra` is independent — Terraform ecosystem + Google Cloud SDK; can be run on its own.
-- `hardware` is independent — hardware-conditional (skipped inside containers and on non-matching DMI).
-- `packages` and `virtualization` are foundational — most other roles will silently no-op or fail without their packages installed.
 
 ## Security: Prohibited Commands
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Hanzo uses Ansible to provision the local machine via `ansible-playbook playbook
 - `ansible.cfg` — local connection, become defaults, roles path
 - `group_vars/all.yml` — package lists, system configuration, and hardware data
 - `requirements.yml` — Galaxy collection dependencies (pinned versions)
-- `roles/` — one role per domain (`foundation`, `packages`, `virtualization`, `trust`, `system`, `languages`, `devtools`, `infra`, `dotfiles`, `security`, `hardware`); each is selectable via `--tags <role>` (see [CLAUDE.md](CLAUDE.md#role-tags))
+- `roles/` — one directory per configured domain; each role declares a tag for selective `--tags <role>` runs
 
 The `hardware` role is dispatched by `ansible_product_name` and skipped automatically inside containers (via `ansible_virtualization_type`).
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Hanzo uses Ansible to provision the local machine via `ansible-playbook playbook
 - `ansible.cfg` — local connection, become defaults, roles path
 - `group_vars/all.yml` — package lists, system configuration, and hardware data
 - `requirements.yml` — Galaxy collection dependencies (pinned versions)
-- `roles/` — one role per domain (`packages`, `virtualization`, `trust`, `system`, `languages`, `devtools`, `infra`, `dotfiles`, `security`, `hardware`); each is selectable via `--tags <role>` (see [CLAUDE.md](CLAUDE.md#role-tags))
+- `roles/` — one role per domain (`foundation`, `packages`, `virtualization`, `trust`, `system`, `languages`, `devtools`, `infra`, `dotfiles`, `security`, `hardware`); each is selectable via `--tags <role>` (see [CLAUDE.md](CLAUDE.md#role-tags))
 
 The `hardware` role is dispatched by `ansible_product_name` and skipped automatically inside containers (via `ansible_virtualization_type`).
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -3,19 +3,6 @@
 # Package lists (roles/packages)
 # ---------------------------------------------------------------------------
 
-base_packages:
-  - fzf
-  - htop
-  - neovim
-  - uv
-  - tree
-  - wget
-  - jq
-  - yq
-  - httpie
-  - whois
-  - tmux
-
 docker_packages:
   - docker
   - docker-buildx
@@ -93,8 +80,6 @@ system_services:
 # User-scoped systemd services (systemctl --user).
 user_services:
   - ssh-agent
-
-system_locale: en_US.UTF-8
 
 # ---------------------------------------------------------------------------
 # Dotfiles and Claude configuration (roles/dotfiles)

--- a/playbook.yml
+++ b/playbook.yml
@@ -35,20 +35,9 @@
       when: hanzo_config_stat.stat.exists
       tags: [always]
 
-    # Shared cache directory used by roles that download upstream
-    # installer scripts (pyenv, gcloud). Lives under $HOME with mode
-    # 0700 so other local users cannot observe or race the file.
-    # check_mode: false ensures the dir exists even in `--check` runs,
-    # so subsequent get_url tasks have a valid dest parent.
-    - name: Ensure Hanzo cache directory exists
-      ansible.builtin.file:
-        path: "{{ ansible_facts.env.HOME }}/.cache/hanzo"
-        state: directory
-        mode: "0700"
-      check_mode: false
-      tags: [always]
-
   roles:
+    - role: foundation
+      tags: [foundation, always]
     - role: packages
       tags: [packages]
     - role: virtualization

--- a/roles/foundation/tasks/main.yml
+++ b/roles/foundation/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Substrate setup that every other role implicitly depends on. The role
+# is tagged `[foundation, always]` in playbook.yml so a selective
+# `--tags <role>` run still establishes this state first.
+
+# Shared cache directory used by roles that download upstream installer
+# scripts (pyenv, gcloud) or fetch verification material (trust). Lives
+# under $HOME with mode 0700 so other local users cannot observe or race
+# the file. check_mode: false ensures the dir exists even in `--check`
+# runs, so subsequent get_url tasks have a valid dest parent.
+- name: Ensure Hanzo cache directory exists
+  ansible.builtin.file:
+    path: "{{ ansible_facts.env.HOME }}/.cache/hanzo"
+    state: directory
+    mode: "0700"
+  check_mode: false
+  become: false
+
+- name: Set system locale
+  ansible.builtin.lineinfile:
+    path: /etc/locale.conf
+    regexp: "^LANG="
+    line: "LANG={{ foundation_locale }}"
+  become: true
+
+# update_cache: true is the canonical pacman DB refresh for the whole
+# provisioning run — foundation is the first role, so every subsequent
+# pacman install sees a fresh database without re-doing the work.
+- name: Install baseline development packages
+  community.general.pacman:
+    name: "{{ foundation_packages }}"
+    update_cache: true
+  become: true

--- a/roles/foundation/tasks/main.yml
+++ b/roles/foundation/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-# Substrate setup that every other role implicitly depends on. The role
-# is tagged `[foundation, always]` in playbook.yml so a selective
-# `--tags <role>` run still establishes this state first.
-
-# Shared cache directory used by roles that download upstream installer
-# scripts (pyenv, gcloud) or fetch verification material (trust). Lives
-# under $HOME with mode 0700 so other local users cannot observe or race
-# the file. check_mode: false ensures the dir exists even in `--check`
-# runs, so subsequent get_url tasks have a valid dest parent.
 - name: Ensure Hanzo cache directory exists
   ansible.builtin.file:
     path: "{{ ansible_facts.env.HOME }}/.cache/hanzo"
@@ -23,9 +14,6 @@
     line: "LANG={{ foundation_locale }}"
   become: true
 
-# update_cache: true is the canonical pacman DB refresh for the whole
-# provisioning run — foundation is the first role, so every subsequent
-# pacman install sees a fresh database without re-doing the work.
 - name: Install baseline development packages
   community.general.pacman:
     name: "{{ foundation_packages }}"

--- a/roles/foundation/vars/main.yml
+++ b/roles/foundation/vars/main.yml
@@ -1,9 +1,4 @@
 ---
-# Substrate state every provisioned machine needs before any other role
-# runs. `foundation_packages` is the baseline CLI toolchain — installed
-# with `update_cache: true` so the pacman DB is fresh for every
-# subsequent role's installs. `foundation_locale` is written to
-# /etc/locale.conf via lineinfile.
 foundation_packages:
   - fzf
   - htop

--- a/roles/foundation/vars/main.yml
+++ b/roles/foundation/vars/main.yml
@@ -1,0 +1,19 @@
+---
+# Substrate state every provisioned machine needs before any other role
+# runs. `foundation_packages` is the baseline CLI toolchain — installed
+# with `update_cache: true` so the pacman DB is fresh for every
+# subsequent role's installs. `foundation_locale` is written to
+# /etc/locale.conf via lineinfile.
+foundation_packages:
+  - fzf
+  - htop
+  - neovim
+  - tree
+  - wget
+  - jq
+  - yq
+  - httpie
+  - whois
+  - tmux
+
+foundation_locale: en_US.UTF-8

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -1,12 +1,6 @@
 ---
 # Package installation — official repos (pacman) and AUR (paru).
 
-- name: Install base development packages
-  community.general.pacman:
-    name: "{{ base_packages }}"
-    update_cache: true
-  become: true
-
 - name: Install Docker packages
   community.general.pacman:
     name: "{{ docker_packages }}"

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -65,10 +65,3 @@
     - system_systemd_running.stat.exists
     - "'XDG_RUNTIME_DIR' in ansible_facts['env']"
   become: false
-
-- name: Set system locale
-  ansible.builtin.lineinfile:
-    path: /etc/locale.conf
-    regexp: "^LANG="
-    line: "LANG={{ system_locale }}"
-  become: true


### PR DESCRIPTION
### Related Issues

No GitHub issue — internal task tracking only.

### Proposed Changes

**PR 3 of 11** in a serialized refactor of the hanzo Ansible role structure.

Extracts substrate state that every other role implicitly depends on into a dedicated `roles/foundation/` role. Foundation is wired as the **first** role in `playbook.yml` with `tags: [foundation, always]`, so it runs before anything else on every invocation — including selective `--tags <role>` runs.

**What moves into `roles/foundation/`:**

- `Ensure Hanzo cache directory exists` — migrated from `playbook.yml` `pre_tasks`. The task retains `check_mode: false` (so `--check` runs still create the dir) and `become: false` (user-space path).
- `Set system locale` — migrated from `roles/system/tasks/main.yml`. Variable renamed `system_locale` → `foundation_locale` per the role-name prefix rule (ansible-lint `var-naming[no-role-prefix]`).
- `Install baseline development packages` — migrated from `roles/packages/tasks/main.yml`. Variable renamed `base_packages` → `foundation_packages`. Foundation now owns the single `update_cache: true` pacman DB refresh for the whole provisioning run; subsequent `community.general.pacman` calls in `roles/packages/` rely on the fresh cache without re-doing the work.

**`uv` is intentionally absent from `foundation_packages`.**

`uv` was `base_packages[3]` in `group_vars/all.yml`. It is installed by `bin/bootstrap.sh` (line 51, real users) and `tests/Containerfile` (line 21, CI) via the Astral installer at `~/.local/bin/uv` **before** `ansible-playbook` runs. That install path means `roles/devtools`'s `uv tool install …` chain keeps working without pacman touching `uv`. A later PR will formalize `uv` install under a dedicated role; not in scope here.

**`always` tag rationale.**

`roles/trust/` (GPG cache paths), `roles/languages/` (pyenv installer), and `roles/infra/` (gcloud installer) all reference `~/.cache/hanzo`. Without `always`, a selective `--tags trust` or `--tags languages` run would fail with a missing parent directory. Tagging `[foundation, always]` guarantees the cache dir exists on every invocation.

**Stale CLAUDE.md edge bullet deleted.**

The `devtools depends on packages — uv tools …` bullet documented a role-to-role edge that no longer exists: no role installs `uv` via pacman after this PR. Removing it follows the same "docs describe present" principle that drives the Rule 6 locale-attribution update (`system` no longer owns locale; `foundation` does).

**Files changed:**

- `roles/foundation/tasks/main.yml` — new, 3 tasks
- `roles/foundation/vars/main.yml` — new, `foundation_packages` (10 entries) + `foundation_locale`
- `playbook.yml` — removes cache-dir `pre_task`; adds `foundation` as first role entry
- `roles/packages/tasks/main.yml` — removes `Install base development packages` task
- `roles/system/tasks/main.yml` — removes `Set system locale` task
- `group_vars/all.yml` — removes `base_packages` list and `system_locale` variable
- `CLAUDE.md` — Rule 6 updated; `foundation` bullet added to Implicit Dependency Edges; stale `devtools → packages (uv)` bullet deleted
- `README.md` — Architecture section role enumeration updated to list `foundation` first

### Testing

- `pre-commit run --all-files` → all hooks pass, ansible-lint clean.
- Full container build `docker build -f tests/Containerfile -t hanzo:test .` → 76 s, PLAY RECAP: `ok=43 changed=27 failed=0 unreachable=0`. Foundation's 3 task banners appear in correct order; the old `packages : Install base development packages` and `system : Set system locale` banners are absent.
- Selective `docker build --build-arg ANSIBLE_ARGS="--tags hardware --check --diff" …` → confirms `foundation` runs first (alongside `always`-tagged `trust` and `system`), and `packages|virtualization|languages|devtools|infra|dotfiles|security` correctly stay out.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`