### PR TITLE
refactor(roles): extract containers role for Docker

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -3,11 +3,6 @@
 # Package lists (roles/packages)
 # ---------------------------------------------------------------------------
 
-docker_packages:
-  - docker
-  - docker-buildx
-  - docker-compose
-
 archive_packages:
   - 7zip
   - unrar
@@ -61,19 +56,13 @@ virtualization_packages:
 # System configuration (roles/system)
 # ---------------------------------------------------------------------------
 
-system_groups:
-  - docker
-
-# Supplementary groups: system_groups + kernel-managed groups.
 user_groups:
-  - docker
   - kvm
   - libvirt
   - render
   - video
 
 system_services:
-  - docker
   - ollama
   - asusd
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -42,6 +42,8 @@
       tags: [packages]
     - role: virtualization
       tags: [virtualization]
+    - role: containers
+      tags: [containers]
     - role: trust
       tags: [trust, always]
     - role: system

--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -18,19 +18,3 @@
     append: true
   when: not ansible_check_mode
   become: true
-
-- name: Detect running systemd
-  ansible.builtin.stat:
-    path: /run/systemd/system
-  register: containers_systemd_running
-  check_mode: false
-
-- name: Enable and start docker service
-  ansible.builtin.systemd_service:
-    name: docker
-    state: started
-    enabled: true
-  when:
-    - not ansible_check_mode
-    - containers_systemd_running.stat.exists
-  become: true

--- a/roles/containers/tasks/main.yml
+++ b/roles/containers/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: Install container packages
+  community.general.pacman:
+    name: "{{ containers_packages }}"
+  become: true
+
+- name: Ensure docker group exists
+  ansible.builtin.group:
+    name: docker
+    system: true
+  check_mode: false
+  become: true
+
+- name: Add user to docker group
+  ansible.builtin.user:
+    name: "{{ ansible_facts['user_id'] }}"
+    groups: docker
+    append: true
+  when: not ansible_check_mode
+  become: true
+
+- name: Detect running systemd
+  ansible.builtin.stat:
+    path: /run/systemd/system
+  register: containers_systemd_running
+  check_mode: false
+
+- name: Enable and start docker service
+  ansible.builtin.systemd_service:
+    name: docker
+    state: started
+    enabled: true
+  when:
+    - not ansible_check_mode
+    - containers_systemd_running.stat.exists
+  become: true

--- a/roles/containers/vars/main.yml
+++ b/roles/containers/vars/main.yml
@@ -1,0 +1,5 @@
+---
+containers_packages:
+  - docker
+  - docker-buildx
+  - docker-compose

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 # Package installation — official repos (pacman) and AUR (paru).
 
-- name: Install Docker packages
-  community.general.pacman:
-    name: "{{ docker_packages }}"
-  become: true
-
 - name: Install archive tools
   community.general.pacman:
     name: "{{ archive_packages }}"

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -1,19 +1,6 @@
 ---
 # System configuration — groups, services, and locale.
 
-# Groups must exist before any consumer task (e.g., a future file write
-# with `group: docker`) can resolve them. `check_mode: false` ensures
-# they're always created, even when other system-role tasks are skipped
-# in check mode — keeping group state consistent across check and live
-# runs.
-- name: Ensure system groups exist
-  ansible.builtin.group:
-    name: "{{ item }}"
-    system: true
-  loop: "{{ system_groups }}"
-  check_mode: false
-  become: true
-
 # Skipped in check mode: render/video groups are kernel-managed and may
 # not exist on the test machine (e.g., inside the CI container), even
 # though they always exist on a real CachyOS system after first boot.


### PR DESCRIPTION
### Related Issues

No linked issue — part of internal swarm task tracking (hanzo-roles-refactor, PR 4 of 11).

### Proposed Changes

Docker management was spread across three roles (`packages`, `system`, `vars`) with no clear ownership. This PR extracts it into a dedicated `containers` role following the one-role-per-domain convention.

- `roles/containers/`: new role owning Docker packages, the `docker` group, user group membership, and the `docker` systemd service
- `roles/containers/vars/main.yml`: package list scoped under the `containers_` prefix (`containers_packages`)
- `playbook.yml`: registers the `containers` role with the `containers` tag, positioned after `virtualization`
- `roles/packages/tasks/main.yml`: removes the `Install Docker packages` task (now owned by `containers`)
- `roles/system/tasks/main.yml`: removes the `Ensure system groups exist` loop for `docker`; `docker` group creation is now handled inline inside `containers`
- `group_vars/all.yml`: removes `docker_packages`, `system_groups`, and `docker` from `user_groups` / `system_services`; these are now role-internal vars

The `containers` role guards `user` and `service` tasks with `when: not ansible_check_mode` and detects running systemd via `stat /run/systemd/system` (consistent with how `system` handles the same pattern).

### Testing

- `pre-commit run --all-files`: passed
- `docker build --build-arg ANSIBLE_ARGS="--tags containers --check --diff" -f tests/Containerfile -t hanzo:test .`: passed
- Full container build (`docker build -f tests/Containerfile -t hanzo:test .`): 44 ok / 27 changed / 0 failed

### Extra Notes

This is **PR 4 of 11** in the `hanzo-roles-refactor` swarm. PRs 1–3 (foundation, trust+security, role tags) have merged. PRs 5/6/7/8/10 are in-flight in parallel and touch the same shared files (`playbook.yml`, `group_vars/all.yml`, `roles/packages/tasks/main.yml`, `roles/system/tasks/main.yml`). Rebases are expected as siblings merge — not a conflict to worry about in this PR.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`