### PR TITLE
refactor(languages): make languages role self-contained

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -14,10 +14,6 @@ asus_packages:
   - asusctl
   - rog-control-center
 
-runtime_packages:
-  - rustup
-  - go
-
 gaming_packages:
   - cachyos-gaming-applications
   - ffmpeg
@@ -30,7 +26,6 @@ desktop_packages:
   - spotify-launcher
 
 aur_packages:
-  - fnm-bin
   - google-chrome
   - wifiman-desktop
 
@@ -110,9 +105,3 @@ gz302_keyboard_target_key: prog1
 # Flip back to 3 if a future kernel/firmware combo fixes the regression.
 # Values: 0 = use default, 1 = ignore, 2 = disable, 3 = enable.
 gz302_wifi_powersave: 2
-
-# ---------------------------------------------------------------------------
-# Go workspace (roles/languages)
-# ---------------------------------------------------------------------------
-
-gopath: ~/programs/go

--- a/roles/languages/tasks/go.yml
+++ b/roles/languages/tasks/go.yml
@@ -1,0 +1,15 @@
+---
+- name: Install Go toolchain packages
+  community.general.pacman:
+    name: "{{ languages_go_packages }}"
+  become: true
+
+- name: Create GOPATH directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - "{{ languages_gopath | expanduser }}"
+    - "{{ languages_gopath | expanduser }}/bin"
+  become: false

--- a/roles/languages/tasks/main.yml
+++ b/roles/languages/tasks/main.yml
@@ -1,66 +1,12 @@
 ---
-# Version managers and language runtimes.
-#
-# Prerequisites: packages role must run first to install rustup, go,
-# fnm-bin, and uv via pacman/paru. In `--check` mode those installs
-# are simulated, so binaries like rustup/fnm are missing — the tasks
-# below that invoke them are gated on `not ansible_check_mode`.
+- name: Configure Python
+  ansible.builtin.include_tasks: python.yml
 
-# pyenv ships an installer script. Download + execute is split so we
-# can avoid risky-shell-pipe and use idempotent get_url instead of curl.
-# Cache lives under $HOME (mode 0700) to avoid /tmp symlink-race surface
-# and shared-/tmp visibility on multi-user systems.
-- name: Download pyenv installer
-  ansible.builtin.get_url:
-    url: https://pyenv.run
-    dest: "{{ ansible_facts.env.HOME }}/.cache/hanzo/pyenv-installer.sh"
-    mode: "0700"
-  become: false
+- name: Configure Rust
+  ansible.builtin.include_tasks: rust.yml
 
-# Skipped in check mode: get_url doesn't actually download the file
-# in check mode, so the installer script isn't on disk to execute.
-- name: Install pyenv via pyenv-installer
-  ansible.builtin.command:
-    cmd: "{{ ansible_facts.env.HOME }}/.cache/hanzo/pyenv-installer.sh"
-    creates: "{{ ansible_facts.env.HOME }}/.pyenv/bin/pyenv"
-  when: not ansible_check_mode
-  become: false
+- name: Configure Node.js
+  ansible.builtin.include_tasks: node.yml
 
-# rustup default stable is idempotent. We can't reliably introspect its
-# stdout for change detection (output varies across versions), so we
-# unconditionally mark unchanged. The first-run "ok" status is cosmetic
-# only — the toolchain is still installed/selected by rustup itself.
-# Skipped in check mode: rustup binary comes from the packages role.
-- name: Set rustup default toolchain to stable
-  ansible.builtin.command: rustup default stable
-  changed_when: false
-  when: not ansible_check_mode
-  become: false
-
-# fnm is installed via paru (aur_packages). Each shell task runs in a
-# fresh process, so we must eval fnm env to activate it. fnm install
-# is idempotent (skips installed versions) — see comment on rustup above
-# for why we use changed_when: false instead of stdout introspection or
-# a static creates: path (LTS version drifts over time).
-# Skipped in check mode: fnm binary comes from the packages role.
-- name: Install Node.js LTS via fnm
-  ansible.builtin.shell: |
-    set -euo pipefail
-    eval "$(fnm env)"
-    fnm install --lts
-    fnm default "$(fnm current)"
-  changed_when: false
-  when: not ansible_check_mode
-  become: false
-
-# Go workspace directories. GOPATH persistence across interactive shell
-# sessions depends on roles/dotfiles (fish shell config).
-- name: Create GOPATH directories
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    mode: "0755"
-  loop:
-    - "{{ gopath | expanduser }}"
-    - "{{ gopath | expanduser }}/bin"
-  become: false
+- name: Configure Go
+  ansible.builtin.include_tasks: go.yml

--- a/roles/languages/tasks/node.yml
+++ b/roles/languages/tasks/node.yml
@@ -1,0 +1,20 @@
+---
+- name: Install Node.js AUR packages
+  kewlfft.aur.aur:
+    name: "{{ languages_node_packages }}"
+    use: paru
+  become: false
+
+# Each shell task runs in a fresh process, so we must eval fnm env to
+# activate it. fnm install is idempotent (skips installed versions) —
+# see Rust for the changed_when: false rationale; a static creates: path
+# can't pin the LTS version because LTS drifts over time.
+- name: Install Node.js LTS via fnm
+  ansible.builtin.shell: |
+    set -euo pipefail
+    eval "$(fnm env)"
+    fnm install --lts
+    fnm default "$(fnm current)"
+  changed_when: false
+  when: not ansible_check_mode
+  become: false

--- a/roles/languages/tasks/python.yml
+++ b/roles/languages/tasks/python.yml
@@ -4,8 +4,10 @@
     name: "{{ languages_python_packages }}"
   become: true
 
-# Cache lives under $HOME (mode 0700) to avoid /tmp symlink-race surface
-# and shared-/tmp visibility on multi-user systems.
+# Download + execute is split (vs. curl | bash) to avoid risky-shell-pipe
+# and to get idempotency via creates: on the execute step. Cache lives
+# under $HOME (mode 0700) to avoid /tmp symlink-race surface and
+# shared-/tmp visibility on multi-user systems.
 - name: Download pyenv installer
   ansible.builtin.get_url:
     url: https://pyenv.run

--- a/roles/languages/tasks/python.yml
+++ b/roles/languages/tasks/python.yml
@@ -1,0 +1,23 @@
+---
+- name: Install Python toolchain packages
+  community.general.pacman:
+    name: "{{ languages_python_packages }}"
+  become: true
+
+# Cache lives under $HOME (mode 0700) to avoid /tmp symlink-race surface
+# and shared-/tmp visibility on multi-user systems.
+- name: Download pyenv installer
+  ansible.builtin.get_url:
+    url: https://pyenv.run
+    dest: "{{ ansible_facts.env.HOME }}/.cache/hanzo/pyenv-installer.sh"
+    mode: "0700"
+  become: false
+
+# Skipped in check mode: get_url doesn't actually download the file in
+# check mode, so the installer script isn't on disk to execute.
+- name: Install pyenv via pyenv-installer
+  ansible.builtin.command:
+    cmd: "{{ ansible_facts.env.HOME }}/.cache/hanzo/pyenv-installer.sh"
+    creates: "{{ ansible_facts.env.HOME }}/.pyenv/bin/pyenv"
+  when: not ansible_check_mode
+  become: false

--- a/roles/languages/tasks/rust.yml
+++ b/roles/languages/tasks/rust.yml
@@ -1,0 +1,15 @@
+---
+- name: Install Rust toolchain packages
+  community.general.pacman:
+    name: "{{ languages_rust_packages }}"
+  become: true
+
+# rustup default stable is idempotent. We can't reliably introspect its
+# stdout for change detection (output varies across versions), so we
+# unconditionally mark unchanged. The first-run "ok" status is cosmetic
+# only — the toolchain is still installed/selected by rustup itself.
+- name: Set rustup default toolchain to stable
+  ansible.builtin.command: rustup default stable
+  changed_when: false
+  when: not ansible_check_mode
+  become: false

--- a/roles/languages/vars/main.yml
+++ b/roles/languages/vars/main.yml
@@ -11,4 +11,4 @@ languages_go_packages:
 languages_node_packages:
   - fnm-bin
 
-languages_gopath: ~/programs/go
+languages_gopath: ~/.golang

--- a/roles/languages/vars/main.yml
+++ b/roles/languages/vars/main.yml
@@ -1,0 +1,14 @@
+---
+languages_python_packages:
+  - uv
+
+languages_rust_packages:
+  - rustup
+
+languages_go_packages:
+  - go
+
+languages_node_packages:
+  - fnm-bin
+
+languages_gopath: ~/programs/go

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -16,11 +16,6 @@
     name: "{{ asus_packages }}"
   become: true
 
-- name: Install language runtimes
-  community.general.pacman:
-    name: "{{ runtime_packages }}"
-  become: true
-
 - name: Install gaming and multimedia
   community.general.pacman:
     name: "{{ gaming_packages }}"


### PR DESCRIPTION
### Related Issues

No tracked issue — internal roles refactor (PR 5 of 11).

### Proposed Changes

The `roles/languages/` role previously relied on `roles/packages/` to pre-install `rustup`, `go`, and `fnm-bin` via pacman/paru, and on `group_vars/all.yml` for the `gopath` variable. This split ownership made it hard to reason about language provisioning in isolation.

This PR makes the role fully self-contained:

- Adds `roles/languages/vars/main.yml` with per-language package lists (`languages_python_packages`, `languages_rust_packages`, `languages_go_packages`, `languages_node_packages`) and `languages_gopath`. All names are prefixed per the `var-naming[no-role-prefix]` rule.
- Splits the single flat `tasks/main.yml` into four focused task files: `python.yml`, `rust.yml`, `node.yml`, `go.yml`. Each file owns the full lifecycle for its language (package install + runtime configuration).
- Rewrites `tasks/main.yml` as an orchestrator of four `include_tasks` calls — no task logic remains in it.
- Drops `runtime_packages`, `fnm-bin` from `aur_packages`, and `gopath` from `group_vars/all.yml`.
- Removes the "Install language runtimes" task from `roles/packages/tasks/main.yml`.

`uv` is restored here (as `languages_python_packages`) after being intentionally dropped from `foundation_packages` in PR #261 as a hand-off to this PR.

### Testing

- Lint: `pre-commit run --all-files`
- Container check: `docker build -f tests/Containerfile -t hanzo:test .`
- Targeted check: `docker build --build-arg ANSIBLE_ARGS="--tags languages --check --diff" -f tests/Containerfile -t hanzo:test .`

### Extra Notes (optional)

The `when: not ansible_check_mode` guards on `rustup`, `fnm`, and `pyenv` tasks are preserved as-is — they rely on binaries installed earlier in the same run and check mode never actually installs them.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`