### PR TITLE
refactor(roles): move asus packages and asusd service into hardware

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,10 +10,6 @@ archive_packages:
 audio_packages:
   - sof-firmware
 
-asus_packages:
-  - asusctl
-  - rog-control-center
-
 gaming_packages:
   - cachyos-gaming-applications
   - ffmpeg
@@ -52,8 +48,7 @@ user_groups:
   - libvirt
   - video
 
-system_services:
-  - asusd
+system_services: []
 
 # User-scoped systemd services (systemctl --user).
 user_services:

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -1,6 +1,29 @@
 ---
 # ASUS ROG Flow Z13 (GZ302) hardware fixes.
 
+- name: Install ASUS packages
+  community.general.pacman:
+    name: "{{ hardware_asus_packages }}"
+  become: true
+
+- name: Detect running systemd
+  ansible.builtin.stat:
+    path: /run/systemd/system
+  register: hardware_systemd_running
+  check_mode: false
+  become: false
+
+- name: Enable and start ASUS services
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  loop: "{{ hardware_asus_services }}"
+  when:
+    - not ansible_check_mode
+    - hardware_systemd_running.stat.exists
+  become: true
+
 - name: Deploy GPU modprobe config
   ansible.builtin.template:
     src: amdgpu.conf.j2

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -1,0 +1,7 @@
+---
+hardware_asus_packages:
+  - asusctl
+  - rog-control-center
+
+hardware_asus_services:
+  - asusd

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -11,11 +11,6 @@
     name: "{{ audio_packages }}"
   become: true
 
-- name: Install ASUS packages
-  community.general.pacman:
-    name: "{{ asus_packages }}"
-  become: true
-
 - name: Install gaming and multimedia
   community.general.pacman:
     name: "{{ gaming_packages }}"


### PR DESCRIPTION
### Related Issues

This is an internal refactor with no associated issue.

### Proposed Changes

Move `asus_packages` install and `asusd` service handling out of `roles/packages/` and `group_vars/all.yml`'s `system_services`, and into `roles/hardware/tasks/gz302.yml` behind the existing GZ302 DMI + container guard. Role-prefixed data (`hardware_asus_packages`, `hardware_asus_services`) is introduced in a new `roles/hardware/vars/main.yml`.

**Scope:**
- `roles/packages/tasks/main.yml`: remove "Install ASUS packages" task and its `asus_packages` reference.
- `group_vars/all.yml`: remove `asus_packages` list and `asusd` from `system_services`.
- `roles/hardware/tasks/gz302.yml`: add "Install ASUS packages", "Detect running systemd", and "Enable and start ASUS services" tasks — all gated by the existing DMI + container guard in the dispatcher.
- `roles/hardware/vars/main.yml` (new): declare `hardware_asus_packages` and `hardware_asus_services` following ansible-lint's `var-naming[no-role-prefix]` rule.

**Behavior change worth noting:** previously `asusctl` and `rog-control-center` installed on every machine; they now install only when the GZ302 DMI is matched. For the current GZ302 machine this is invisible. For a future non-GZ302 ASUS machine, the dispatcher would need widening or an `asus_*` matcher extracted above GZ302 specificity — this is deliberate tightening, not a regression.

**Why `gz302_*` data stayed in `group_vars/all.yml`:** moving it into `roles/hardware/vars/main.yml` would require renaming every key to `hardware_gz302_*` (ansible-lint's `var-naming[no-role-prefix]` rule binds top-level keys in role `vars/main.yml`) and cascading the rename through four templates and `gz302.yml`'s `lineinfile` reference. That is a separate concern deferred to a follow-up PR.

**Why "Detect running systemd" lives inside `gz302.yml`** rather than the dispatcher: only the asus service tasks consume it. Co-locating the probe with its only consumer keeps the dispatcher minimal. The duplication with `roles/system/tasks/main.yml`'s identical probe is intentional — selective `--tags hardware` runs need the probe present in the hardware role's own task stream.

### Testing

- `pre-commit run --all-files` — clean.
- Full container build (`docker build -f tests/Containerfile -t hanzo:test .`) — clean; rest of the playbook works without `asus_packages`; PLAY RECAP: ok=42 changed=26 failed=0.
- Selective `docker build --build-arg ANSIBLE_ARGS="--tags hardware --check --diff" -f tests/Containerfile -t hanzo:test .` — confirms the dispatcher skips the new asus tasks inside the container (container guard fires as expected).

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`