### PR TITLE
feat(desktop): add zed, ghostty, and darkly

### DIFF
--- a/roles/desktop/vars/main.yml
+++ b/roles/desktop/vars/main.yml
@@ -8,11 +8,14 @@ desktop_pacman:
   - signal-desktop
   - moonlight-qt
   - spotify-launcher
+  - zed
+  - ghostty
 
 desktop_aur:
   - google-chrome
   - wifiman-desktop
   - zoom
+  - darkly
 
 desktop_user_groups:
   - video


### PR DESCRIPTION
### Related Issues

_No GitHub issue — tracked as PR 12 in the team task tracker._

### Proposed Changes:

Three packages added to `roles/desktop/vars/main.yml` — pure data-only edit, `+3 -0`. No task or playbook changes; the existing pacman and AUR install tasks already loop over these lists.

| Package | Source | Description |
|---------|--------|-------------|
| `zed` | `[extra]` (pacman) | Code editor |
| `ghostty` | `[extra]` (pacman) | Terminal emulator |
| `darkly` | AUR | Qt/KF6 application style, Plasma window decoration, and color scheme (forked from Lightly) |

**darkly activation note:** darkly is not a Global Theme — it does not auto-apply on install. After install, activate via Plasma System Settings → Colors and Themes → Application Style + Window Decorations + Colors. Each component is set independently.

### Testing:

- [x] `pre-commit run --all-files` passes
- [x] `docker build -f tests/Containerfile -t hanzo:test .` succeeds (full `--check --diff` run: `ok=50 changed=26 failed=0`)
- [x] `docker build --build-arg ANSIBLE_ARGS="--tags desktop --check --diff" -f tests/Containerfile -t hanzo:test .` shows new packages in the desktop install diffs:

  ```
  TASK [desktop : Install desktop pacman packages] ***
  +ghostty-1.3.1-2
  +ghostty-shell-integration-1.3.1-2
  +ghostty-terminfo-1.3.1-2
  +zed-1.2.6-1

  TASK [desktop : Install desktop AUR packages] ***
  +google-chrome
  +wifiman-desktop
  +zoom
  +darkly
  ```

- [x] `cachyos/cachyos:latest` does NOT already ship any of the three packages (`pacman -Qq darkly zed ghostty` against the base image returns "package not found" for all three — no CLAUDE.md rule-5 collision)

### Extra Notes (optional):

<!-- none -->

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`