### PR TITLE
fix(virtualization): gate libvirtd block on stat-based systemd check

### DIFF
--- a/roles/virtualization/tasks/main.yml
+++ b/roles/virtualization/tasks/main.yml
@@ -35,13 +35,25 @@
   when: not ansible_check_mode
   become: true
 
+- name: Detect running systemd
+  ansible.builtin.stat:
+    path: /run/systemd/system
+  register: virtualization_systemd_running
+  check_mode: false
+  become: false
+
 # --check simulates the pacman install, so virsh wouldn't exist on
-# first run. Containers lack PID-1 systemd and /dev/kvm, so libvirtd
-# cannot run. Same guard shape as roles/hardware.
+# first run. Without PID-1 systemd (container builds, chroots, BuildKit
+# RUN steps), libvirtd cannot start — gate on /run/systemd/system rather
+# than ansible_facts['virtualization_type'], because the latter is
+# unreliable under BuildKit (the docker fact is not always populated at
+# play start, so the previous guard leaked the systemd_service call
+# into container builds). Same gating primitive as roles/home and
+# roles/hardware/gz302.yml.
 - name: Configure libvirt default network autostart
   when:
     - not ansible_check_mode
-    - ansible_facts['virtualization_type'] | default('') not in ['docker', 'container', 'podman']
+    - virtualization_systemd_running.stat.exists
   block:
     # virsh needs libvirtd reachable for the probe and the flag flip
     # below. state: started only — persisting the socket would


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes

**Root cause:** `roles/virtualization` guarded the `libvirtd.socket`/`virsh` block with:

```yaml
when:
  - ansible_facts['virtualization_type'] | default('') not in ['docker', 'container', 'podman']
```

During a BuildKit `RUN` step, the `docker` fact is not always populated at play start, so the guard leaked the `systemd_service: libvirtd.socket` task into container builds. The task returned `ok` via module leniency but emitted:

```
[WARNING]: Target is a chroot or systemd is offline
```

The role was relying on accidental forgiveness instead of skipping cleanly.

**Fix:** Replaced the fact-based guard with a stat-based `/run/systemd/system` check — the same defense-in-depth primitive already used in `roles/home/tasks/main.yml` and `roles/hardware/tasks/gz302.yml`.

A `Detect running systemd` task is added; the block's `when:` now consumes `virtualization_systemd_running.stat.exists`.

### Testing

First end-to-end **real** provisioning test (no `--check`) since the refactor began:

```
docker build --build-arg ANSIBLE_ARGS="" -f tests/Containerfile -t hanzo:test .
```

PLAY RECAP after fix:

```
ok=68   changed=36   unreachable=0   failed=0   skipped=9   rescued=0   ignored=0
```

No Ansible warnings.

### Extra Notes (optional)

The `Detect running systemd` stat pattern now appears in three roles (`home`, `hardware/gz302.yml`, `virtualization`). Consolidating into a play-scoped shared fact or shared task file is a structural change — flagged for a separate refactor PR and out of scope here.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`