### PR TITLE
fix(hardware): patch wifi first to prevent TCP stalls

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -59,10 +59,6 @@
           become: true
           tags: [always]
 
-        # Hardware runs first so the MT7925 wifi-powersave fix is
-        # applied before any other role starts downloading. The wifi
-        # handler is flushed inside the role; the boot-regen handler
-        # fires once at end-of-play.
         - name: Run hardware role
           ansible.builtin.import_role:
             name: hardware

--- a/playbook.yml
+++ b/playbook.yml
@@ -59,24 +59,19 @@
           become: true
           tags: [always]
 
-        - name: Run foundation role
-          ansible.builtin.import_role:
-            name: foundation
-          tags: [foundation, always]
-
-        # Hardware runs early so the MT7925 wifi-powersave drop-in is in
-        # place before the AUR-heavy roles below start downloading.
-        # NM's default powersave (3) silently stalls long-running curl
-        # transfers on this chip — Firefox masks it, but paru/makepkg do
-        # not. flush_handlers forces "Reload NetworkManager" to fire now
-        # rather than at end-of-play.
+        # Hardware runs first so the MT7925 wifi-powersave fix is
+        # applied before any other role starts downloading. The wifi
+        # handler is flushed inside the role; the boot-regen handler
+        # fires once at end-of-play.
         - name: Run hardware role
           ansible.builtin.import_role:
             name: hardware
           tags: [hardware]
 
-        - name: Flush handlers so hardware fixes take effect immediately
-          ansible.builtin.meta: flush_handlers
+        - name: Run foundation role
+          ansible.builtin.import_role:
+            name: foundation
+          tags: [foundation, always]
 
         - name: Run desktop role
           ansible.builtin.import_role:

--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart network stack and cycle wifi
+- name: Restart network stack
   ansible.builtin.shell: |
     set -euo pipefail
     systemctl restart NetworkManager
@@ -9,7 +9,7 @@
   changed_when: true
   become: true
 
-- name: Regenerate initramfs and Limine entries
+- name: Regenerate initramfs
   ansible.builtin.command: limine-mkinitcpio
   changed_when: true
   become: true

--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -1,11 +1,15 @@
 ---
-- name: Rebuild initramfs
-  ansible.builtin.command: mkinitcpio -P
+- name: Restart network stack and cycle wifi
+  ansible.builtin.shell: |
+    set -euo pipefail
+    systemctl restart NetworkManager
+    nmcli radio wifi off
+    nmcli radio wifi on
+    sleep 5
   changed_when: true
   become: true
 
-- name: Reload NetworkManager
-  ansible.builtin.systemd_service:
-    name: NetworkManager
-    state: reloaded
+- name: Regenerate initramfs and Limine entries
+  ansible.builtin.command: limine-mkinitcpio
+  changed_when: true
   become: true

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -10,7 +10,7 @@
     dest: /etc/NetworkManager/conf.d/wifi-powersave.conf
     mode: "0644"
   become: true
-  notify: Restart network stack and cycle wifi
+  notify: Restart network stack
 
 - name: Apply wifi powersave before continuing
   ansible.builtin.meta: flush_handlers
@@ -44,15 +44,19 @@
     dest: /etc/modprobe.d/amdgpu.conf
     mode: "0644"
   become: true
-  notify: Regenerate initramfs and Limine entries
+  notify: Regenerate initramfs
 
+# Regex matches only a dedicated single-param Hanzo line so an existing
+# inline mix like `KERNEL_CMDLINE[default]+=" amdgpu.dcdebugmask=X foo=bar"`
+# is never replaced (which would drop foo=bar). On first run we append a
+# new dedicated line; on re-runs we update its value in place.
 - name: Ensure OLED kernel param in Limine cmdline
   ansible.builtin.lineinfile:
     path: /etc/default/limine
-    regexp: 'amdgpu\.dcdebugmask='
+    regexp: '^KERNEL_CMDLINE\[default\]\+="\s*amdgpu\.dcdebugmask=\S+\s*"\s*$'
     line: 'KERNEL_CMDLINE[default]+=" {{ hardware_gz302_oled_kernel_param }}"'
   become: true
-  notify: Regenerate initramfs and Limine entries
+  notify: Regenerate initramfs
 
 - name: Deploy suspend/resume hook
   ansible.builtin.template:

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -1,6 +1,20 @@
 ---
 # ASUS ROG Flow Z13 (GZ302) hardware fixes.
 
+# Wifi-powersave fix runs first and is flushed immediately so the
+# MT7925 stops dropping long-running TCP transfers before any role
+# downloads anything (paru/curl in later roles, pacman in this one).
+- name: Deploy NetworkManager wifi powersave drop-in
+  ansible.builtin.template:
+    src: wifi-powersave.conf.j2
+    dest: /etc/NetworkManager/conf.d/wifi-powersave.conf
+    mode: "0644"
+  become: true
+  notify: Restart network stack and cycle wifi
+
+- name: Apply wifi powersave before continuing
+  ansible.builtin.meta: flush_handlers
+
 - name: Install ASUS packages
   community.general.pacman:
     name: "{{ hardware_asus_packages }}"
@@ -30,15 +44,15 @@
     dest: /etc/modprobe.d/amdgpu.conf
     mode: "0644"
   become: true
-  notify: Rebuild initramfs
+  notify: Regenerate initramfs and Limine entries
 
-- name: Ensure OLED kernel param in cmdline
+- name: Ensure OLED kernel param in Limine cmdline
   ansible.builtin.lineinfile:
-    path: /etc/kernel/cmdline
+    path: /etc/default/limine
     regexp: 'amdgpu\.dcdebugmask='
-    line: "{{ hardware_gz302_oled_kernel_param }}"
+    line: 'KERNEL_CMDLINE[default]+=" {{ hardware_gz302_oled_kernel_param }}"'
   become: true
-  notify: Rebuild initramfs
+  notify: Regenerate initramfs and Limine entries
 
 - name: Deploy suspend/resume hook
   ansible.builtin.template:
@@ -46,11 +60,3 @@
     dest: /usr/lib/systemd/system-sleep/gz302-suspend.sh
     mode: "0755"
   become: true
-
-- name: Deploy NetworkManager wifi powersave drop-in
-  ansible.builtin.template:
-    src: wifi-powersave.conf.j2
-    dest: /etc/NetworkManager/conf.d/wifi-powersave.conf
-    mode: "0644"
-  become: true
-  notify: Reload NetworkManager

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -46,14 +46,10 @@
   become: true
   notify: Regenerate initramfs
 
-# Regex matches only a dedicated single-param Hanzo line so an existing
-# inline mix like `KERNEL_CMDLINE[default]+=" amdgpu.dcdebugmask=X foo=bar"`
-# is never replaced (which would drop foo=bar). On first run we append a
-# new dedicated line; on re-runs we update its value in place.
 - name: Ensure OLED kernel param in Limine cmdline
   ansible.builtin.lineinfile:
     path: /etc/default/limine
-    regexp: '^KERNEL_CMDLINE\[default\]\+="\s*amdgpu\.dcdebugmask=\S+\s*"\s*$'
+    regexp: '^KERNEL_CMDLINE\[default\]\+=" amdgpu\.dcdebugmask='
     line: 'KERNEL_CMDLINE[default]+=" {{ hardware_gz302_oled_kernel_param }}"'
   become: true
   notify: Regenerate initramfs

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -6,9 +6,10 @@ hardware_asus_packages:
 hardware_asus_services:
   - asusd
 
-# Disable Panel Replay (DC_DISABLE_REPLAY=0x400) on the Strix Halo OLED panel
-# to prevent scrolling artifacts and flicker on DCN 3.5.
-hardware_gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x400"
+# Disable Panel Replay (DC_DISABLE_REPLAY=0x400) and PSR-SU
+# (DC_DISABLE_PSR_SU=0x200) on the Strix Halo OLED panel to prevent
+# scrolling artifacts and flicker on DCN 3.5.
+hardware_gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x600"
 
 # Force ABM off: kernel auto-skip on OLED was reverted in 2024; PPD engages
 # ABM on battery and causes visible gamma/red-shift on AMD OLED panels.


### PR DESCRIPTION
### Related Issues

N/A

### Proposed Changes:

Three coupled bugs in the GZ302 hardware role, fixed together because they share the same handler refactor:

**1. OLED kernel param written to wrong file**

`/etc/kernel/cmdline` (UKI convention) does not exist on a default CachyOS install. The cmdline lives in `/etc/default/limine` and is consumed by `limine-mkinitcpio`. The `lineinfile` task is retargeted at the correct path with the proper `KERNEL_CMDLINE[default]+=` syntax.

**2. Wifi-powersave fix applied too late**

The MT7925 wifi-powersave drop-in was the last task in `gz302.yml`, meaning paru/curl downloads in later roles (desktop, ai, security) were stalling on the powersave bug before the fix took effect. The task is now first in the role, followed immediately by `meta: flush_handlers`, so the fix is active before any download runs.

**3. `dcdebugmask` value too low (`0x400` → `0x600`)**

`0x400` disables Panel Replay but leaves PSR-SU active, which causes scrolling artifacts on the Strix Halo OLED panel. `0x600` disables both (Panel Replay + PSR-SU), per upstream guidance.

**Handler refactor (necessary for the above):**

- Old: `Rebuild initramfs` (mkinitcpio -P) + `Reload NetworkManager` (systemctl reload)
- New: `Restart network stack and cycle wifi` (NM restart + radio off/on + 5s reconnect wait) and `Regenerate initramfs and Limine entries` (runs `limine-mkinitcpio`, the CachyOS canonical command that does initramfs rebuild + Limine entries update in a single step)

The now-stale `meta: flush_handlers` after the hardware role in `playbook.yml` is removed; the wifi flush moved inside the role, and the boot-regen handler fires once at end-of-play via Ansible's handler dedup.

### Testing:

```
docker build --build-arg ANSIBLE_ARGS="--tags hardware --check --diff" \
  -f tests/Containerfile -t hanzo:test .
```

Verify in the diff output:
- `/etc/NetworkManager/conf.d/wifi-powersave.conf` is written first, handler flushed before ASUS packages install
- `/etc/default/limine` receives the `amdgpu.dcdebugmask=0x600` line (not `/etc/kernel/cmdline`)
- `limine-mkinitcpio` is queued (not `mkinitcpio -P`)

### Extra Notes (optional):

The three changes are tightly coupled through the handler rename; splitting them into separate commits would leave the role in a broken state between commits.

### Checklist

- [x] Related issue and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`