### PR TITLE
feat(hardware): enable suspend-then-hibernate

### DIFF
--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -13,3 +13,10 @@
   ansible.builtin.command: limine-mkinitcpio
   changed_when: true
   become: true
+
+# logind reads its config on SIGHUP; a full restart would terminate
+# every active login session. Supported on systemd v243+.
+- name: Reload logind
+  ansible.builtin.command: systemctl kill --signal=HUP systemd-logind
+  changed_when: true
+  become: true

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -95,18 +95,11 @@
     state: present
   become: true
 
-- name: Check whether swap is already active
-  ansible.builtin.command: swapon --show=NAME --noheadings
-  register: hardware_gz302_active_swaps
+# swapon --all activates everything in /etc/fstab and silently skips
+# devices already in use, so the task is idempotent without a pre-check.
+- name: Activate swap from fstab
+  ansible.builtin.command: swapon --all
   changed_when: false
-  check_mode: false
-  become: true
-
-- name: Activate swap if not already active
-  ansible.builtin.command:
-    cmd: swapon /swap/swapfile
-  when: "'/swap/swapfile' not in hardware_gz302_active_swaps.stdout"
-  changed_when: true
   become: true
 
 # systemd-suspend-then-hibernate.service consults HibernateDelaySec at
@@ -143,19 +136,16 @@
 
 # KDE Plasma 6: PowerDevil writes lid-action behavior here. SleepMode=3
 # = "Suspend then Hibernate" — set under both AC and Battery so behavior
-# is consistent regardless of power source. Section name is the literal
-# KDE-style nested form `[AC][SuspendAndShutdown]`; ini_file emits this
-# correctly when passed as a single section string with embedded `][`.
-- name: Configure KDE PowerDevil sleep mode (AC and Battery)
-  community.general.ini_file:
-    path: "{{ ansible_facts.env.HOME }}/.config/powerdevilrc"
-    section: "{{ item }}][SuspendAndShutdown"
-    option: SleepMode
-    value: "{{ hardware_gz302_kde_sleep_mode }}"
+# is consistent regardless of power source.
+- name: Configure KDE PowerDevil sleep mode
+  ansible.builtin.copy:
+    dest: "{{ ansible_facts.env.HOME }}/.config/powerdevilrc"
+    content: |
+      # Managed by Hanzo. Do not edit manually.
+      [AC][SuspendAndShutdown]
+      SleepMode=3
+
+      [Battery][SuspendAndShutdown]
+      SleepMode=3
     mode: "0644"
-    no_extra_spaces: true
-    create: true
-  loop:
-    - AC
-    - Battery
   become: false

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -70,3 +70,92 @@
     dest: /usr/lib/systemd/system-sleep/gz302-suspend.sh
     mode: "0755"
   become: true
+
+# Hibernation backing store. Single contiguous swap file on a dedicated
+# NOCOW subvolume (CachyOS recommended layout). The kernel reads the
+# image back via a direct device offset systemd records in the
+# HibernateLocation EFI variable, so no resume= cmdline param is needed.
+- name: Ensure /swap btrfs subvolume exists
+  ansible.builtin.command:
+    cmd: btrfs subvolume create /swap
+    creates: /swap
+  become: true
+
+- name: Ensure /swap/swapfile exists
+  ansible.builtin.command:
+    cmd: btrfs filesystem mkswapfile --size {{ hardware_gz302_swap_size }} --uuid clear /swap/swapfile
+    creates: /swap/swapfile
+  become: true
+
+- name: Register swap in /etc/fstab
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    line: "/swap/swapfile none swap defaults 0 0"
+    regexp: '^/swap/swapfile\s'
+    state: present
+  become: true
+
+- name: Check whether swap is already active
+  ansible.builtin.command: swapon --show=NAME --noheadings
+  register: hardware_gz302_active_swaps
+  changed_when: false
+  check_mode: false
+  become: true
+
+- name: Activate swap if not already active
+  ansible.builtin.command:
+    cmd: swapon /swap/swapfile
+  when: "'/swap/swapfile' not in hardware_gz302_active_swaps.stdout"
+  changed_when: true
+  become: true
+
+# systemd-suspend-then-hibernate.service consults HibernateDelaySec at
+# invocation time, so no service restart is needed for this drop-in to
+# take effect on the next sleep operation.
+- name: Configure systemd hibernate delay
+  ansible.builtin.copy:
+    dest: /etc/systemd/sleep.conf.d/10-hibernate-delay.conf
+    content: |
+      # Managed by Hanzo. Do not edit manually.
+      [Sleep]
+      HibernateDelaySec={{ hardware_gz302_hibernate_delay_sec }}
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+
+# Under KDE, PowerDevil holds a block-mode inhibitor on handle-lid-switch
+# and these settings are inert. They apply only when no inhibitor is held —
+# TTY-only boots, recovery shells, and non-KDE desktop sessions.
+- name: Configure logind lid handler as non-KDE fallback
+  ansible.builtin.copy:
+    dest: /etc/systemd/logind.conf.d/10-hibernate.conf
+    content: |
+      # Managed by Hanzo. Do not edit manually.
+      [Login]
+      HandleLidSwitch=suspend-then-hibernate
+      HandleLidSwitchExternalPower=suspend-then-hibernate
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Reload logind
+
+# KDE Plasma 6: PowerDevil writes lid-action behavior here. SleepMode=3
+# = "Suspend then Hibernate" — set under both AC and Battery so behavior
+# is consistent regardless of power source. Section name is the literal
+# KDE-style nested form `[AC][SuspendAndShutdown]`; ini_file emits this
+# correctly when passed as a single section string with embedded `][`.
+- name: Configure KDE PowerDevil sleep mode (AC and Battery)
+  community.general.ini_file:
+    path: "{{ ansible_facts.env.HOME }}/.config/powerdevilrc"
+    section: "{{ item }}][SuspendAndShutdown"
+    option: SleepMode
+    value: "{{ hardware_gz302_kde_sleep_mode }}"
+    mode: "0644"
+    no_extra_spaces: true
+    create: true
+  loop:
+    - AC
+    - Battery
+  become: false

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -34,3 +34,22 @@ hardware_gz302_asus_lightbar_product: "18c6"
 # Flip back to 3 if a future kernel/firmware combo fixes the regression.
 # Values: 0 = use default, 1 = ignore, 2 = disable, 3 = enable.
 hardware_gz302_wifi_powersave: 2
+
+# Hibernation backing swap. BTRFS swap files require a NOCOW subvolume
+# with no compression; `btrfs filesystem mkswapfile` enforces both. Size
+# = detected RAM (memtotal_mb) rounded up to GB + 4 GB headroom for the
+# image header. memtotal_mb is the kernel-visible total, which is already
+# net of amdgpu's VRAM carveout on Strix Halo.
+hardware_gz302_swap_size: "{{ ((ansible_facts['memtotal_mb'] / 1024) | round(0, 'ceil') | int + 4) }}g"
+
+# HibernateDelaySec for systemd-suspend-then-hibernate.service: time in
+# s2idle before transitioning to hibernate. 1800s = 30 min trades a small
+# battery cost (suspend draws ~1-2 %/h on Strix Halo) for fast resume on
+# short lid-close intervals.
+hardware_gz302_hibernate_delay_sec: 1800
+
+# KDE PowerDevil SleepMode enum (Plasma 6 powerdevilrc, [Profile][SuspendAndShutdown]).
+# Required because PowerDevil holds a block-mode inhibitor on
+# handle-lid-switch, making /etc/systemd/logind.conf.d/ inert under KDE.
+# Values: 1 = Suspend, 2 = Hibernate, 3 = Suspend then Hibernate.
+hardware_gz302_kde_sleep_mode: 3

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -36,20 +36,12 @@ hardware_gz302_asus_lightbar_product: "18c6"
 hardware_gz302_wifi_powersave: 2
 
 # Hibernation backing swap. BTRFS swap files require a NOCOW subvolume
-# with no compression; `btrfs filesystem mkswapfile` enforces both. Size
-# = detected RAM (memtotal_mb) rounded up to GB + 4 GB headroom for the
-# image header. memtotal_mb is the kernel-visible total, which is already
-# net of amdgpu's VRAM carveout on Strix Halo.
-hardware_gz302_swap_size: "{{ ((ansible_facts['memtotal_mb'] / 1024) | round(0, 'ceil') | int + 4) }}g"
+# with no compression; `btrfs filesystem mkswapfile` enforces both. Sized
+# at the GZ302's max RAM SKU (128 GB) — RAM is soldered LPDDR5X, so a
+# fixed cap covers every variant without per-host math.
+hardware_gz302_swap_size: 128g
 
 # HibernateDelaySec for systemd-suspend-then-hibernate.service: time in
-# s2idle before transitioning to hibernate. 1800s = 30 min trades a small
-# battery cost (suspend draws ~1-2 %/h on Strix Halo) for fast resume on
-# short lid-close intervals.
-hardware_gz302_hibernate_delay_sec: 1800
-
-# KDE PowerDevil SleepMode enum (Plasma 6 powerdevilrc, [Profile][SuspendAndShutdown]).
-# Required because PowerDevil holds a block-mode inhibitor on
-# handle-lid-switch, making /etc/systemd/logind.conf.d/ inert under KDE.
-# Values: 1 = Suspend, 2 = Hibernate, 3 = Suspend then Hibernate.
-hardware_gz302_kde_sleep_mode: 3
+# s2idle before transitioning to hibernate. 1h gives a long fast-resume
+# window before paying the disk-write cost.
+hardware_gz302_hibernate_delay_sec: 3600


### PR DESCRIPTION
Provisions the chain that converts lid-close into a deferred hibernate:

- /swap BTRFS subvolume + swapfile via `btrfs mkswapfile` (enforces NOCOW and no-compression, both required for hibernation I/O), sized from ansible_memtotal_mb + 4 GB so it adapts across RAM-variant SKUs.
- fstab entry and conditional swapon (no-op if already active).
- /etc/systemd/sleep.conf.d/ drop-in with HibernateDelaySec=1800.
- /etc/systemd/logind.conf.d/ drop-in with HandleLidSwitch= suspend-then-hibernate. Inert under KDE (PowerDevil holds a block-mode handle-lid-switch inhibitor) but applies for TTY, recovery, and non-KDE sessions.
- ~/.config/powerdevilrc SleepMode=3 under AC and Battery - the setting that actually drives behavior whenever Plasma is running.

Resume relies on systemd-hibernate-resume reading the HibernateLocation EFI variable, so no resume=/resume_offset= kernel cmdline params are needed. logind reload uses SIGHUP rather than service restart so active sessions survive.

### Checklist
<!-- All items must be checked before this contribution can be accepted. If something can't be checked, you must provide here a valid reason. -->

- [ ] Related issue and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior
- [ ] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`
