### PR TITLE
fix(home): write git identity to ~/.gitidentity sidecar

### DIFF
--- a/roles/home/tasks/main.yml
+++ b/roles/home/tasks/main.yml
@@ -16,19 +16,21 @@
   when: not ansible_check_mode
   become: false
 
-- name: Set git user.name
+- name: Set git user.name in identity sidecar
   community.general.git_config:
     name: user.name
     value: "{{ hanzo_fullname }}"
-    scope: global
+    scope: file
+    file: "{{ home_gitidentity_file | expanduser }}"
   when: hanzo_fullname is defined
   become: false
 
-- name: Set git user.email
+- name: Set git user.email in identity sidecar
   community.general.git_config:
     name: user.email
     value: "{{ hanzo_email }}"
-    scope: global
+    scope: file
+    file: "{{ home_gitidentity_file | expanduser }}"
   when: hanzo_email is defined
   become: false
 

--- a/roles/home/vars/main.yml
+++ b/roles/home/vars/main.yml
@@ -7,3 +7,7 @@ home_claude_config_dir: ~/.claude
 
 home_user_services:
   - ssh-agent
+
+# Path must match `[include] path = ...` in palazzem/dotfiles gitconfig.
+# Renaming this breaks the cross-repo include and silently drops identity.
+home_gitidentity_file: ~/.gitidentity


### PR DESCRIPTION
### Related Issues

- fixes #277

### Proposed Changes:

The dotfiles `install.sh` runs `cp -f .../gitconfig ~/.gitconfig` on every provisioning run, wiping the `[user]` section. The previous fix re-added identity via `community.general.git_config` with `scope: global`, but that left a race window: between `install.sh` completing and the `home` role's `git_config` tasks running, `~/.gitconfig` had no `[user]` section. Any interrupt in that window left identity gone until the next successful full run.

This PR moves the two `git_config` tasks to `scope: file` with `file: ~/.gitidentity` — a sidecar path that `install.sh` never touches. Identity is now order-independent and survives interrupts.

Core changes:
- `roles/home/tasks/main.yml` — both `user.name` and `user.email` `git_config` tasks switched from `scope: global` to `scope: file` writing to `home_gitidentity_file`; task names updated to reflect the sidecar.
- `roles/home/vars/main.yml` — new `home_gitidentity_file: ~/.gitidentity` var with a WHY comment about the cross-repo include contract.

### Testing:

- `pre-commit run --all-files` clean.
- `docker build --build-arg ANSIBLE_ARGS=\"--tags home --check --diff\" -f tests/Containerfile -t hanzo:test .` passes; check-mode diff shows both identity tasks writing `user.name` / `user.email` to `/home/testuser/.gitidentity` with the expected values.
- Manual verification on the GZ302 deferred to post-merge.

### Extra Notes (optional):

Hard prerequisite: relies on palazzem/dotfiles@278f86b8ee17dfb358f044215934272bc12fa623, which introduces `[include] path = ~/.gitidentity` in the gitconfig template so git transparently reads identity from the sidecar. The SHA is pinned in the commit body.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`