### PR TITLE
fix(system): pre-create systemd sleep/logind .conf.d dirs

### DIFF
--- a/roles/system/tasks/hibernate.yml
+++ b/roles/system/tasks/hibernate.yml
@@ -30,6 +30,20 @@
   changed_when: false
   become: true
 
+# systemd ships sleep.conf and logind.conf, but not their .conf.d/
+# drop-in directories — ansible.builtin.copy does not create parent
+# directories, so the drop-in writes below fail on a fresh system
+# unless these are precreated.
+- name: Ensure systemd drop-in directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - /etc/systemd/sleep.conf.d
+    - /etc/systemd/logind.conf.d
+  become: true
+
 # systemd-suspend-then-hibernate.service consults HibernateDelaySec at
 # invocation time, so no service restart is needed for this drop-in to
 # take effect on the next sleep operation.


### PR DESCRIPTION
### Related Issues

N/A

### Proposed Changes:

`ansible.builtin.copy` does not create missing parent directories. On a fresh system `/etc/systemd/sleep.conf.d` and `/etc/systemd/logind.conf.d` do not exist, which causes the suspend-then-hibernate drop-in writes to fail at provisioning time with `/etc/systemd/sleep.conf.d does not exist`.

This adds an `ansible.builtin.file` task (idempotent, `state: directory`) to `roles/system/tasks/hibernate.yml` that pre-creates both drop-in directories before the writes, fixing first-run provisioning on the GZ302.

### Testing:

- `pre-commit run --all-files` — passes
- `docker build --build-arg ANSIBLE_ARGS="--tags system --check --diff" -f tests/Containerfile -t hanzo:test .` — passes (system role is gated under the host_has_systemd fact and remains a no-op in the container)

### Extra Notes (optional):

Mirrors the pre-create pattern used for `/etc/asusd` in #274 (commit a91f63c). Rebased onto current main after #283 / #284, which moved hibernate config from `roles/hardware/tasks/gz302.yml` to `roles/system/tasks/hibernate.yml`.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`