### PR TITLE
fix(guard): resolve `set_fact` self-reference on real hosts

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -39,7 +39,7 @@
         host_has_systemd: "{{ hanzo_systemd_stat.stat.exists }}"
         model_is_gz302: "{{ 'product_name' in ansible_facts
                            and 'GZ302' in ansible_facts['product_name']
-                           and host_has_systemd }}"
+                           and hanzo_systemd_stat.stat.exists }}"
       become: false
       tags: [always]
 


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

`set_fact` evaluates all keys against the same variable scope that existed *before* the task runs — a key defined earlier in the same task is not visible to keys defined later. The consolidation in #283 introduced `model_is_gz302` referencing `host_has_systemd` within the same `set_fact` block, which fails with `'host_has_systemd' is undefined` on any host where `product_name` is present in `ansible_facts` (e.g., the GZ302).

The container test masked the bug because the container has no DMI data, so `'product_name' in ansible_facts` short-circuits to `False` before the broken cross-fact reference is ever evaluated.

Fix: replace `host_has_systemd` with `hanzo_systemd_stat.stat.exists` directly — the same source of truth used to set `host_has_systemd`, eliminating the intra-task dependency.

### Testing:

- Container check passes (`docker build -f tests/Containerfile -t hanzo:test .`) — the container path (no DMI) is unchanged.
- The GZ302 path is validated by code inspection: `hanzo_systemd_stat` is registered in the preceding task and is always available when `set_fact` runs.

### Extra Notes (optional):

This is a one-line fix; the only file changed is `playbook.yml`.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`