### PR TITLE
fix(hardware): remap Copilot chord to bare F23

### DIFF
--- a/roles/hardware/templates/keyd-default.conf.j2
+++ b/roles/hardware/templates/keyd-default.conf.j2
@@ -2,5 +2,7 @@
 *
 
 [main]
-# ASUS Copilot key (Microsoft spec: LeftShift+LeftMeta+F23) -> F13.
-leftshift+leftmeta+f23 = f13
+# ASUS Copilot key (Microsoft spec: LeftShift+LeftMeta+F23) -> bare F23.
+# Without stripping the modifiers, KDE only receives LeftShift+LeftMeta
+# (the F23 keysym never reaches userspace as part of the chord).
+leftshift+leftmeta+f23 = f23

--- a/roles/home/tasks/main.yml
+++ b/roles/home/tasks/main.yml
@@ -82,7 +82,7 @@
 # refresh bindings written by external tools — the binding
 # activates at the next KDE session start. The loop exists because
 # community.general.ini_file writes one option per invocation.
-- name: Bind Copilot key (F13) to Claude Code launcher in KDE
+- name: Bind Copilot key (F23) to Claude Code launcher in KDE
   community.general.ini_file:
     path: "{{ ansible_facts.env.HOME }}/.config/kglobalshortcutsrc"
     section: hanzo-claude-code.desktop
@@ -93,7 +93,7 @@
     - option: _k_friendly_name
       value: Claude Code
     - option: _launch
-      value: "F13,none,Claude Code"
+      value: "F23"
   loop_control:
     label: "{{ item.option }}"
   become: false


### PR DESCRIPTION
### Related Issues

N/A

### Proposed Changes:

The ASUS Copilot key fires a `LeftShift+LeftMeta+F23` chord per the Microsoft hardware spec. The previous keyd mapping remapped that chord to `F13`, which XKB then silently rewrites to `XF86Tools` — a keysym that KDE maps by default to "Open System Settings", causing an unintended collision.

Two changes fix the root cause:

- **`roles/hardware/templates/keyd-default.conf.j2`**: remap the chord to bare `F23` instead of `F13`. Stripping the modifier keys is essential: without it, KDE only receives the `LeftShift+LeftMeta` modifier state and the `F23` keysym never reaches userspace as part of the chord.
- **`roles/home/tasks/main.yml`**: update the `kglobalshortcutsrc` `_launch` value from `F13,none,Claude Code` to `F23`. KDE accepts a bare keysym here; the extra `,none,...` fields are optional and were carried forward from an earlier format.

After provisioning, the Copilot key delivers a clean `F23` keysym to KDE, which routes it exclusively to the Claude Code launcher with no default-binding collisions.

### Testing:

- Container check: `docker build --build-arg ANSIBLE_ARGS="--tags hardware,home --check --diff" -f tests/Containerfile -t hanzo:test .`
- Full container run: `docker build --build-arg ANSIBLE_ARGS="--tags hardware,home" -f tests/Containerfile -t hanzo:test .`
- Manual: press Copilot key after provisioning and verify Claude Code launches (not System Settings).

### Extra Notes (optional):

`F23` is in the range `F13`–`F35` that XKB leaves untouched (no symbolic alias), so it survives XKB processing as-is. `F13` is the first key in that range that XKB does remap to `XF86Tools`, hence the collision.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`