### PR TITLE
fix(system): switch ZRam to Zswap so hibernation resumes

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -138,17 +138,8 @@
           become: true
           tags: [always]
 
-  # Cross-role handlers live in the play. Handler scope is play-wide
-  # regardless of where a handler is defined, and ansible dedupes handler
-  # runs by name — so two roles notifying one play-level handler produce a
-  # single run, while two identically-bodied role-local handlers under
-  # different names would run twice. limine-mkinitcpio regenerates the
-  # initramfs for every installed kernel and rewrites the Limine boot
-  # entries from /etc/default/limine; both the hardware role (GZ302 GPU
-  # modprobe config, OLED kernel param) and the system role (Zswap kernel
-  # params, lz4 initramfs module) change inputs to that same command.
-  # Notified handlers run regardless of --tags filtering, so no tag is
-  # needed here for selective runs (`--tags hardware`, `--tags system`).
+  # Regenerates the initramfs for every installed kernel and rewrites the
+  # Limine boot entries from /etc/default/limine.
   handlers:
     - name: Regenerate initramfs
       ansible.builtin.command: limine-mkinitcpio

--- a/playbook.yml
+++ b/playbook.yml
@@ -137,3 +137,20 @@
             state: absent
           become: true
           tags: [always]
+
+  # Cross-role handlers live in the play. Handler scope is play-wide
+  # regardless of where a handler is defined, and ansible dedupes handler
+  # runs by name — so two roles notifying one play-level handler produce a
+  # single run, while two identically-bodied role-local handlers under
+  # different names would run twice. limine-mkinitcpio regenerates the
+  # initramfs for every installed kernel and rewrites the Limine boot
+  # entries from /etc/default/limine; both the hardware role (GZ302 GPU
+  # modprobe config, OLED kernel param) and the system role (Zswap kernel
+  # params, lz4 initramfs module) change inputs to that same command.
+  # Notified handlers run regardless of --tags filtering, so no tag is
+  # needed here for selective runs (`--tags hardware`, `--tags system`).
+  handlers:
+    - name: Regenerate initramfs
+      ansible.builtin.command: limine-mkinitcpio
+      changed_when: true
+      become: true

--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -9,10 +9,9 @@
   changed_when: true
   become: true
 
-- name: Regenerate initramfs
-  ansible.builtin.command: limine-mkinitcpio
-  changed_when: true
-  become: true
+# `Regenerate initramfs`, notified by the GZ302 tasks in this role, is
+# defined at play level in playbook.yml: the system role notifies it too,
+# and one play-level definition keeps ansible's per-name dedupe intact.
 
 - name: Restart keyd
   ansible.builtin.systemd_service:

--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -9,10 +9,6 @@
   changed_when: true
   become: true
 
-# `Regenerate initramfs`, notified by the GZ302 tasks in this role, is
-# defined at play level in playbook.yml: the system role notifies it too,
-# and one play-level definition keeps ansible's per-name dedupe intact.
-
 - name: Restart keyd
   ansible.builtin.systemd_service:
     name: keyd

--- a/roles/system/handlers/main.yml
+++ b/roles/system/handlers/main.yml
@@ -1,6 +1,16 @@
 ---
 # logind reads its config on SIGHUP; a full restart would terminate
 # every active login session. Supported on systemd v243+.
+# Deliberately role-local rather than reusing the hardware role's
+# equivalent handler: handler names resolve globally, and sharing one
+# would tie the system role's hibernation tasks to a role that only runs
+# on matching hardware. limine-mkinitcpio regenerates the initramfs and
+# rewrites the Limine boot entries from /etc/default/limine.
+- name: Rebuild initramfs
+  ansible.builtin.command: limine-mkinitcpio
+  changed_when: true
+  become: true
+
 - name: Reload logind
   ansible.builtin.command: systemctl kill --signal=HUP systemd-logind
   changed_when: true

--- a/roles/system/handlers/main.yml
+++ b/roles/system/handlers/main.yml
@@ -1,8 +1,4 @@
 ---
-# `Regenerate initramfs`, notified by the hibernation tasks in this role,
-# is defined at play level in playbook.yml: the hardware role notifies it
-# too, and one play-level definition keeps ansible's per-name dedupe intact.
-
 # logind reads its config on SIGHUP; a full restart would terminate
 # every active login session. Supported on systemd v243+.
 - name: Reload logind

--- a/roles/system/handlers/main.yml
+++ b/roles/system/handlers/main.yml
@@ -1,16 +1,10 @@
 ---
+# `Regenerate initramfs`, notified by the hibernation tasks in this role,
+# is defined at play level in playbook.yml: the hardware role notifies it
+# too, and one play-level definition keeps ansible's per-name dedupe intact.
+
 # logind reads its config on SIGHUP; a full restart would terminate
 # every active login session. Supported on systemd v243+.
-# Deliberately role-local rather than reusing the hardware role's
-# equivalent handler: handler names resolve globally, and sharing one
-# would tie the system role's hibernation tasks to a role that only runs
-# on matching hardware. limine-mkinitcpio regenerates the initramfs and
-# rewrites the Limine boot entries from /etc/default/limine.
-- name: Rebuild initramfs
-  ansible.builtin.command: limine-mkinitcpio
-  changed_when: true
-  become: true
-
 - name: Reload logind
   ansible.builtin.command: systemctl kill --signal=HUP systemd-logind
   changed_when: true

--- a/roles/system/tasks/hibernate.yml
+++ b/roles/system/tasks/hibernate.yml
@@ -76,14 +76,9 @@
 # mounted, so lz4 must ship inside the initramfs. mkinitcpio (>= 38)
 # concatenates /etc/mkinitcpio.conf.d/*.conf after the main config and
 # sources the result, so `MODULES+=(lz4)` appends to the MODULES array
-# without rewriting /etc/mkinitcpio.conf in place.
-- name: Ensure mkinitcpio drop-in directory exists
-  ansible.builtin.file:
-    path: /etc/mkinitcpio.conf.d
-    state: directory
-    mode: "0755"
-  become: true
-
+# without rewriting /etc/mkinitcpio.conf in place. The mkinitcpio package
+# owns /etc/mkinitcpio.conf.d/, so — unlike the systemd drop-in
+# directories below — it needs no pre-create task.
 - name: Add lz4 to initramfs MODULES
   ansible.builtin.copy:
     dest: /etc/mkinitcpio.conf.d/10-zswap.conf

--- a/roles/system/tasks/hibernate.yml
+++ b/roles/system/tasks/hibernate.yml
@@ -1,4 +1,46 @@
 ---
+# CachyOS defaults to ZRam: zram-generator declares a RAM-sized zram0 swap
+# at priority 100 and cachyos-settings ships a udev rule that force-disables
+# Zswap on every zram0 change event. RAM-backed swap cannot hold a
+# hibernation image, so the machine never resumes. The tasks below follow
+# the CachyOS wiki "Switching from ZRam to Zswap" procedure:
+# https://wiki.cachyos.org/configuration/general_system_tweaks/#swap-configuration
+
+# Kernel params live in /etc/default/limine; limine-mkinitcpio regenerates
+# the boot entries and the initramfs from it, so both param tasks and the
+# mkinitcpio drop-in below share the same handler.
+- name: Ensure ZRam is disabled in Limine cmdline
+  ansible.builtin.lineinfile:
+    path: /etc/default/limine
+    regexp: '^KERNEL_CMDLINE\[default\]\+=" systemd\.zram='
+    line: 'KERNEL_CMDLINE[default]+=" {{ system_zram_kernel_param }}"'
+  become: true
+  notify: Rebuild initramfs
+
+- name: Ensure Zswap kernel params in Limine cmdline
+  ansible.builtin.lineinfile:
+    path: /etc/default/limine
+    regexp: '^KERNEL_CMDLINE\[default\]\+=" zswap\.'
+    line: 'KERNEL_CMDLINE[default]+=" {{ system_zswap_kernel_params }}"'
+  become: true
+  notify: Rebuild initramfs
+
+# /usr/lib/udev/rules.d/30-zram.rules (cachyos-settings) writes `N` to
+# /sys/module/zswap/parameters/enabled whenever zram0 changes state. A
+# rule-free file of the same name in /etc/udev/rules.d shadows it — udev
+# resolves rule files by name, /etc winning over /usr/lib.
+- name: Override CachyOS udev rule that disables Zswap
+  ansible.builtin.copy:
+    dest: /etc/udev/rules.d/30-zram.rules
+    content: |
+      # Managed by Hanzo. Do not edit manually.
+      # Intentionally rule-free: shadows /usr/lib/udev/rules.d/30-zram.rules,
+      # which disables Zswap and raises vm.swappiness for ZRam.
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+
 # Hibernation backing store. Single contiguous swap file on a dedicated
 # NOCOW subvolume (CachyOS recommended layout). The kernel reads the
 # image back via a direct device offset systemd records in the
@@ -29,6 +71,30 @@
   ansible.builtin.command: swapon --all
   changed_when: false
   become: true
+
+# zswap.compressor=lz4 is applied at boot, before the root filesystem is
+# mounted, so lz4 must ship inside the initramfs. mkinitcpio (>= 38)
+# concatenates /etc/mkinitcpio.conf.d/*.conf after the main config and
+# sources the result, so `MODULES+=(lz4)` appends to the MODULES array
+# without rewriting /etc/mkinitcpio.conf in place.
+- name: Ensure mkinitcpio drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/mkinitcpio.conf.d
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Add lz4 to initramfs MODULES
+  ansible.builtin.copy:
+    dest: /etc/mkinitcpio.conf.d/10-zswap.conf
+    content: |
+      # Managed by Hanzo. Do not edit manually.
+      MODULES+=(lz4)
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Rebuild initramfs
 
 # systemd ships sleep.conf and logind.conf, but not their .conf.d/
 # drop-in directories — ansible.builtin.copy does not create parent

--- a/roles/system/tasks/hibernate.yml
+++ b/roles/system/tasks/hibernate.yml
@@ -15,7 +15,7 @@
     regexp: '^KERNEL_CMDLINE\[default\]\+=" systemd\.zram='
     line: 'KERNEL_CMDLINE[default]+=" {{ system_zram_kernel_param }}"'
   become: true
-  notify: Rebuild initramfs
+  notify: Regenerate initramfs
 
 - name: Ensure Zswap kernel params in Limine cmdline
   ansible.builtin.lineinfile:
@@ -23,7 +23,7 @@
     regexp: '^KERNEL_CMDLINE\[default\]\+=" zswap\.'
     line: 'KERNEL_CMDLINE[default]+=" {{ system_zswap_kernel_params }}"'
   become: true
-  notify: Rebuild initramfs
+  notify: Regenerate initramfs
 
 # /usr/lib/udev/rules.d/30-zram.rules (cachyos-settings) writes `N` to
 # /sys/module/zswap/parameters/enabled whenever zram0 changes state. A
@@ -89,7 +89,7 @@
     group: root
     mode: "0644"
   become: true
-  notify: Rebuild initramfs
+  notify: Regenerate initramfs
 
 # systemd ships sleep.conf and logind.conf, but not their .conf.d/
 # drop-in directories — ansible.builtin.copy does not create parent

--- a/roles/system/vars/main.yml
+++ b/roles/system/vars/main.yml
@@ -16,6 +16,15 @@ system_locale: en_US.UTF-8
 # Hibernation swap for a 128 GB system.
 system_swap_size: 128g
 
+# Kernel params for the CachyOS "Switching from ZRam to Zswap" procedure.
+# ZRam is RAM-backed and cannot hold a hibernation image, so it is turned
+# off and Zswap takes over as the compressed cache in front of the swap
+# file. Pool percentage and compressor are the values the wiki recommends.
+system_zram_kernel_param: systemd.zram=0
+system_zswap_kernel_params: >-
+  zswap.enabled=1 zswap.shrinker_enabled=1
+  zswap.compressor=lz4 zswap.max_pool_percent=30
+
 # HibernateDelaySec for systemd-suspend-then-hibernate.service: time in
 # s2idle before transitioning to hibernate. 3h gives a long fast-resume
 # window before paying the disk-write cost.


### PR DESCRIPTION
**Claude Harness**

Hibernation never resumed because provisioning left CachyOS's ZRam setup in place: `zram-generator` declares a RAM-sized `zram0` swap at priority 100 and `cachyos-settings` ships a udev rule that force-disables Zswap on every `zram0` change event, so the hibernation image had no persistent backing store. The hibernation tasks previously implemented only the Btrfs swapfile half of the CachyOS wiki "Switching from ZRam to Zswap" procedure; this PR adds the missing steps — `systemd.zram=0` and the `zswap.*` kernel params in `/etc/default/limine`, a rule-free `/etc/udev/rules.d/30-zram.rules` override, `lz4` appended to the initramfs `MODULES` via an `/etc/mkinitcpio.conf.d` drop-in, and a `limine-mkinitcpio` rebuild handler.

## Run record

- **Issue:** #290
- **Type:** bug — confirmed at `/deliver`
- **Session:** `7f4e4da2-18b0-4571-aa59-582bebf8fe64` — resume with `claude --resume 7f4e4da2-18b0-4571-aa59-582bebf8fe64`
