### PR TITLE
feat(ai)!: replace ollama with llama.cpp on the ROCm backend

### DIFF
--- a/roles/ai/tasks/main.yml
+++ b/roles/ai/tasks/main.yml
@@ -10,10 +10,14 @@
     name: "{{ ai_pacman }}"
   become: true
 
+# No check-mode gate: render and video are static system groups (systemd
+# sysusers.d/basic.conf), so they exist in the test container too, and the
+# user module resolves every name in `groups` even under --check. Running
+# the task in the container build is what makes a missing or renamed group
+# fail the run instead of passing green on a skip.
 - name: Add user to AI supplementary groups
   ansible.builtin.user:
     name: "{{ ansible_facts['user_id'] }}"
     groups: "{{ ai_user_groups }}"
     append: true
-  when: not ansible_check_mode
   become: true

--- a/roles/ai/tasks/main.yml
+++ b/roles/ai/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+# Local inference is start-on-demand: the llama-cpp package ships
+# llama-server.service (system and user units), and this role
+# deliberately never enables or starts either. Nothing listens until
+# the owner launches llama-server (or a llama-cli run) by hand.
+#
+# Model files are out of scope — this role installs tooling only.
 - name: Install AI pacman packages
   community.general.pacman:
     name: "{{ ai_pacman }}"

--- a/roles/ai/vars/main.yml
+++ b/roles/ai/vars/main.yml
@@ -22,11 +22,11 @@ ai_pacman:
 # ROCm requires membership in both render and video per AMD docs
 # (https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/prerequisites.html):
 # render gates DRM render-node access, video gates the legacy
-# video-device path. Both are kernel-managed (udev creates them when
-# GPU devices appear), so they're absent in containers — gating
-# consumed by the role's user task. video is also declared in the
-# desktop role's desktop_user_groups for general graphics access;
-# the duplicate append is idempotent.
+# video-device path. Both are static system groups declared in systemd's
+# sysusers.d/basic.conf, so they exist on any systemd host and in the
+# test container — the role's user task therefore runs unconditionally.
+# video is also declared in the desktop role's desktop_user_groups for
+# general graphics access; the duplicate append is idempotent.
 ai_user_groups:
   - render
   - video

--- a/roles/ai/vars/main.yml
+++ b/roles/ai/vars/main.yml
@@ -1,6 +1,23 @@
 ---
+# llama.cpp from the CachyOS-provided repos (Arch `extra`, mirrored by
+# CachyOS). Upstream splits the runtime into the frontend binaries
+# (llama-cpp) and one package per ggml backend, loaded dynamically at
+# runtime — so the backend set is chosen here, by which ggml-* packages
+# get installed.
 ai_pacman:
-  - ollama-rocm
+  # CLI tooling and the HTTP server: /usr/bin/llama-cli,
+  # /usr/bin/llama-server, plus llama-bench/llama-quantize et al.
+  - llama-cpp
+  # ROCm/HIP backend, the GPU path on this machine's AMD GPU; pulls
+  # rocm-hip-runtime, hipblas and rocblas as hard dependencies. Declared
+  # an optional dep by `ggml`, so it is not implied by llama-cpp and has
+  # to be requested explicitly.
+  - ggml-hip
+  # CPU backend, also an optional dep of `ggml`. Required for everything
+  # that stays on the host — tokenization and any layer not offloaded —
+  # so llama.cpp stays usable when a model exceeds VRAM or the GPU
+  # backend is unavailable.
+  - ggml-cpu
 
 # ROCm requires membership in both render and video per AMD docs
 # (https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/prerequisites.html):


### PR DESCRIPTION
**Claude Harness**

Replaces ollama with llama.cpp as the machine's local inference stack, per #292: the `ai` role now installs the CachyOS-provided `llama-cpp` package (CLI + `llama-server`) together with the `ggml-hip` (ROCm/HIP) and `ggml-cpu` backends, which upstream ships as separate, dynamically loaded packages. The `render`/`video` group membership that AMD GPU compute needs is unchanged, nothing is enabled at boot — `llama-cpp` ships `llama-server.service` units that the role deliberately leaves disabled — and no ollama package reference remains in provisioning. Existing ollama installs are untouched; their cleanup is the owner's separate task.

## Run record

- **Issue:** #292
- **Type:** change — confirmed at `/deliver`
- **Session:** `2b073410-e8fc-4c6e-80d5-a52268b29770` — resume with `claude --resume 2b073410-e8fc-4c6e-80d5-a52268b29770`
