### PR TITLE
feat(desktop): add plasma-keyboard package

### DIFF
--- a/roles/desktop/vars/main.yml
+++ b/roles/desktop/vars/main.yml
@@ -11,6 +11,7 @@ desktop_pacman:
   - zed
   - ghostty
   - wl-clipboard
+  - plasma-keyboard
 
 desktop_aur:
   - google-chrome


### PR DESCRIPTION
## What

Adds `plasma-keyboard` (KDE's on-screen virtual keyboard, Plasma 6.6+) to the desktop role's pacman package list.

## Why

Touch/tablet text input on provisioned machines (e.g. the GZ302): CachyOS's KDE install ships no virtual keyboard, and the package is not in the base image.

## Verification

- `pre-commit run --all-files` passes.
- Container check build (`docker build -f tests/Containerfile -t hanzo:test .`) passes.

Install-only: selecting it as the active KWin virtual keyboard is left to System Settings.