### PR TITLE
feat(home): auto-bind Copilot key (F23) to the Claude Code launcher on KDE hosts

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -31,12 +31,26 @@
       become: false
       tags: [always]
 
+    # "KDE host" means Plasma is *installed*, not that a session is
+    # running: provisioning over SSH/TTY must still write the KDE config
+    # that activates at the next login. /usr/bin/plasmashell is the
+    # install marker; session-scoped signals (KDE_FULL_SESSION,
+    # XDG_CURRENT_DESKTOP) are absent on a headless run and would wrongly
+    # skip the binding.
+    - name: Detect installed KDE Plasma
+      ansible.builtin.stat:
+        path: /usr/bin/plasmashell
+      register: hanzo_plasma_stat
+      become: false
+      tags: [always]
+
     # `'product_name' in ansible_facts` short-circuits the GZ302 check
     # so it's safe even when the DMI fact is missing (gather_subset
     # without `hardware`, or non-Linux DMI paths).
     - name: Compute provisioning facts
       ansible.builtin.set_fact:
         host_has_systemd: "{{ hanzo_systemd_stat.stat.exists }}"
+        host_has_kde: "{{ hanzo_plasma_stat.stat.exists }}"
         model_is_gz302: "{{ 'product_name' in ansible_facts
                            and 'GZ302' in ansible_facts['product_name']
                            and hanzo_systemd_stat.stat.exists }}"

--- a/roles/home/tasks/kde.yml
+++ b/roles/home/tasks/kde.yml
@@ -1,0 +1,35 @@
+---
+# KDE Plasma user-side configuration: files that live in the user's home
+# and are read by Plasma at session start. Writing them from an SSH/TTY
+# run is fine — they activate at the next login.
+
+# ansible.builtin.template does not create parent directories, and a
+# fresh home has no ~/.local/share/applications yet.
+- name: Ensure ~/.local/share/applications exists
+  ansible.builtin.file:
+    path: "{{ ansible_facts.env.HOME }}/.local/share/applications"
+    state: directory
+    mode: "0755"
+  become: false
+
+- name: Deploy Claude Code launcher .desktop entry
+  ansible.builtin.template:
+    src: hanzo-claude-code.desktop.j2
+    dest: "{{ ansible_facts.env.HOME }}/.local/share/applications/{{ home_claude_launcher_file }}"
+    mode: "0644"
+  become: false
+
+# kglobalacceld reads launcher shortcuts only from the nested
+# `[services][<file>.desktop]` group; top-level `[<file>.desktop]` groups
+# are ignored and deleted on daemon start. ini_file has no nested-group
+# syntax, hence the `]`+`[` embedded in `section`.
+- name: Bind Copilot key (F23) to Claude Code launcher in KDE
+  community.general.ini_file:
+    path: "{{ ansible_facts.env.HOME }}/.config/kglobalshortcutsrc"
+    section: "services][{{ home_claude_launcher_file }}"
+    option: _launch
+    value: "F23"
+    no_extra_spaces: true
+    mode: "0644"
+  when: host_has_kde
+  become: false

--- a/roles/home/tasks/main.yml
+++ b/roles/home/tasks/main.yml
@@ -76,3 +76,24 @@
     dest: "{{ ansible_facts.env.HOME }}/.local/share/applications/hanzo-claude-code.desktop"
     mode: "0644"
   become: false
+
+# kglobalacceld (Plasma 6) reads launcher shortcuts from the *nested*
+# `[services][<file>.desktop]` group of kglobalshortcutsrc, with the bare
+# key sequence as value — see kglobalacceld's GlobalShortcutsRegistry::
+# loadSettings() and KServiceActionComponent::loadSettings(). Top-level
+# `[<file>.desktop]` groups — the shape used before #289 — are skipped by
+# loadSettings() and deleted by migrateConfig() on every daemon start,
+# which is why that earlier write never took effect. ini_file has no
+# nested-group syntax, hence the `]`+`[` embedded in `section`.
+# Writing this from an SSH/TTY run is fine: kglobalacceld reads the file
+# at session start, so the binding activates at the next login.
+- name: Bind Copilot key (F23) to Claude Code launcher in KDE
+  community.general.ini_file:
+    path: "{{ ansible_facts.env.HOME }}/.config/kglobalshortcutsrc"
+    section: "services][hanzo-claude-code.desktop"
+    option: _launch
+    value: "F23"
+    no_extra_spaces: true
+    mode: "0644"
+  when: host_has_kde
+  become: false

--- a/roles/home/tasks/main.yml
+++ b/roles/home/tasks/main.yml
@@ -60,42 +60,5 @@
     mode: "0755"
   become: false
 
-# ansible.builtin.template does not create parent directories.
-# On a fresh KDE setup ~/.local/share/applications may not exist
-# yet — pre-create it so the template task is robust on first run.
-- name: Ensure ~/.local/share/applications exists
-  ansible.builtin.file:
-    path: "{{ ansible_facts.env.HOME }}/.local/share/applications"
-    state: directory
-    mode: "0755"
-  become: false
-
-- name: Deploy Claude Code launcher .desktop entry
-  ansible.builtin.template:
-    src: hanzo-claude-code.desktop.j2
-    dest: "{{ ansible_facts.env.HOME }}/.local/share/applications/{{ home_claude_launcher_file }}"
-    mode: "0644"
-  become: false
-
-# kglobalacceld (Plasma 6) reads launcher shortcuts from the *nested*
-# `[services][<file>.desktop]` group of kglobalshortcutsrc, with the bare
-# key sequence as value — see kglobalacceld's GlobalShortcutsRegistry::
-# loadSettings() and KServiceActionComponent::loadSettings(). Top-level
-# `[<file>.desktop]` groups — the shape used before #289 — are skipped by
-# loadSettings() and deleted by migrateConfig() on every daemon start,
-# which is why that earlier write never took effect. ini_file has no
-# nested-group syntax, hence the `]`+`[` embedded in `section`.
-# The launcher basename comes from home_claude_launcher_file — the same
-# var the template task deploys under, since the two must match exactly.
-# Writing this from an SSH/TTY run is fine: kglobalacceld reads the file
-# at session start, so the binding activates at the next login.
-- name: Bind Copilot key (F23) to Claude Code launcher in KDE
-  community.general.ini_file:
-    path: "{{ ansible_facts.env.HOME }}/.config/kglobalshortcutsrc"
-    section: "services][{{ home_claude_launcher_file }}"
-    option: _launch
-    value: "F23"
-    no_extra_spaces: true
-    mode: "0644"
-  when: host_has_kde
-  become: false
+- name: Configure KDE Plasma user settings
+  ansible.builtin.include_tasks: kde.yml

--- a/roles/home/tasks/main.yml
+++ b/roles/home/tasks/main.yml
@@ -73,7 +73,7 @@
 - name: Deploy Claude Code launcher .desktop entry
   ansible.builtin.template:
     src: hanzo-claude-code.desktop.j2
-    dest: "{{ ansible_facts.env.HOME }}/.local/share/applications/hanzo-claude-code.desktop"
+    dest: "{{ ansible_facts.env.HOME }}/.local/share/applications/{{ home_claude_launcher_file }}"
     mode: "0644"
   become: false
 
@@ -85,12 +85,14 @@
 # loadSettings() and deleted by migrateConfig() on every daemon start,
 # which is why that earlier write never took effect. ini_file has no
 # nested-group syntax, hence the `]`+`[` embedded in `section`.
+# The launcher basename comes from home_claude_launcher_file — the same
+# var the template task deploys under, since the two must match exactly.
 # Writing this from an SSH/TTY run is fine: kglobalacceld reads the file
 # at session start, so the binding activates at the next login.
 - name: Bind Copilot key (F23) to Claude Code launcher in KDE
   community.general.ini_file:
     path: "{{ ansible_facts.env.HOME }}/.config/kglobalshortcutsrc"
-    section: "services][hanzo-claude-code.desktop"
+    section: "services][{{ home_claude_launcher_file }}"
     option: _launch
     value: "F23"
     no_extra_spaces: true

--- a/roles/home/templates/hanzo-claude-code.desktop.j2
+++ b/roles/home/templates/hanzo-claude-code.desktop.j2
@@ -1,14 +1,3 @@
-{#
-  Exec notes:
-  - The home path is templated in because %h is not a Desktop Entry field
-    code (only %f %F %u %U %i %c %k are) and would be passed through
-    literally by the launcher.
-  - `claude` is an npm global under the fnm-managed Node version, so it is
-    only on PATH once the shell environment is loaded (dotfiles
-    conf.d/environment.fish, which fish sources for every session kind).
-    A desktop activation starts from the session environment, which has no
-    fnm PATH entry — hence `fish -c claude` instead of a bare `claude`.
--#}
 [Desktop Entry]
 Type=Application
 Name=Claude Code

--- a/roles/home/templates/hanzo-claude-code.desktop.j2
+++ b/roles/home/templates/hanzo-claude-code.desktop.j2
@@ -1,8 +1,19 @@
+{#
+  Exec notes:
+  - The home path is templated in because %h is not a Desktop Entry field
+    code (only %f %F %u %U %i %c %k are) and would be passed through
+    literally by the launcher.
+  - `claude` is an npm global under the fnm-managed Node version, so it is
+    only on PATH once the shell environment is loaded (dotfiles
+    conf.d/environment.fish, which fish sources for every session kind).
+    A desktop activation starts from the session environment, which has no
+    fnm PATH entry — hence `fish -c claude` instead of a bare `claude`.
+-#}
 [Desktop Entry]
 Type=Application
 Name=Claude Code
 Comment=Open Claude Code in ~/cowork
-Exec=ghostty --working-directory=%h/cowork -e claude agents
+Exec=ghostty --working-directory={{ ansible_facts.env.HOME }}/cowork -e fish -c claude
 Icon=utilities-terminal
 Terminal=false
 Categories=Utility;Development;

--- a/roles/home/vars/main.yml
+++ b/roles/home/vars/main.yml
@@ -11,3 +11,11 @@ home_user_services:
 # Path must match `[include] path = ...` in palazzem/dotfiles gitconfig.
 # Renaming this breaks the cross-repo include and silently drops identity.
 home_gitidentity_file: ~/.gitidentity
+
+# Basename of the Claude Code launcher entry. kglobalacceld resolves the
+# global shortcut to the launcher *by this filename*: the deployed file in
+# ~/.local/share/applications and the `[services][<file>]` group in
+# kglobalshortcutsrc must stay byte-identical, so both use this var.
+# Renaming it in only one place leaves the shortcut pointing at a
+# nonexistent service and the Copilot key silently goes dead.
+home_claude_launcher_file: hanzo-claude-code.desktop

--- a/roles/home/vars/main.yml
+++ b/roles/home/vars/main.yml
@@ -12,10 +12,7 @@ home_user_services:
 # Renaming this breaks the cross-repo include and silently drops identity.
 home_gitidentity_file: ~/.gitidentity
 
-# Basename of the Claude Code launcher entry. kglobalacceld resolves the
-# global shortcut to the launcher *by this filename*: the deployed file in
-# ~/.local/share/applications and the `[services][<file>]` group in
-# kglobalshortcutsrc must stay byte-identical, so both use this var.
-# Renaming it in only one place leaves the shortcut pointing at a
-# nonexistent service and the Copilot key silently goes dead.
+# KDE resolves the global shortcut to the launcher by this filename, so the
+# deployed .desktop file and the kglobalshortcutsrc group must match exactly.
+# Renaming it in only one place silently kills the Copilot key.
 home_claude_launcher_file: hanzo-claude-code.desktop


### PR DESCRIPTION
**Claude Harness**

Restores the automatic KDE-side binding of `F23` to the Claude Code launcher (removed in #289) so the Copilot key works after a provisioning run with no System Settings step, and fixes the launcher's `Exec` line: it is now spec-valid, opens Ghostty in `~/cowork`, and runs plain `claude`. The binding is written to the group kglobalacceld actually reads on Plasma 6 — the nested `[services][hanzo-claude-code.desktop]` group with a bare key sequence — which is why the pre-#289 top-level `[hanzo-claude-code.desktop]` group never took effect.

## Run record

- **Issue:** #297
- **Type:** change — confirmed at `/deliver`
- **Session:** `ea4b2d65-17c6-4981-aaf1-cd3ce4a7a8af` — resume with `claude --resume ea4b2d65-17c6-4981-aaf1-cd3ce4a7a8af`

### Related Issues

- fixes #297

### Proposed Changes:

**Detection fact (`playbook.yml` pre_tasks)** — new `host_has_kde`, stat of `/usr/bin/plasmashell`. "KDE host" means Plasma is *installed*, not that a session is running, so provisioning over SSH/TTY still writes the config; session-scoped signals (`KDE_FULL_SESSION`, `XDG_CURRENT_DESKTOP`) would wrongly skip the binding on a headless run. Per CLAUDE.md rule 3 the fact lives in `pre_tasks`; the role only consumes it.

**KDE binding (`roles/home/tasks/kde.yml`)** — one `community.general.ini_file` task, gated on `host_has_kde`, writing `_launch=F23` into `~/.config/kglobalshortcutsrc`. The KDE user-side tasks (launcher entry + binding) live in their own `kde.yml`, included unconditionally from `roles/home/tasks/main.yml`, so further KDE settings have an obvious home.

Why the group changed shape vs. the pre-#289 task — read from kglobalacceld 6.7.4 (the version Arch/CachyOS ships, `extra/kglobalacceld 6.7.4-1`):

- `GlobalShortcutsRegistry::loadSettings()` iterates top-level groups and **skips** any group ending in `.desktop`, then loads launcher shortcuts from `_config.group("services").group(<name>.desktop)` — i.e. the INI group `[services][hanzo-claude-code.desktop]`.
- `GlobalShortcutsRegistry::migrateConfig()` runs at daemon construction and **deletes** top-level `<name>.desktop` groups, migrating only values that are a valid `shortcut,default,friendly` triplet.
- The old task wrote a top-level `[hanzo-claude-code.desktop]` group with `_launch=F23` (not a triplet), so it was dropped on the first daemon start and never registered. That is the concrete reason the pre-#289 binding did not stick — not #289's stated causes.
- `KServiceActionComponent::loadSettings()` reads `_launch` as a bare key sequence (`configGroup.readEntry("_launch", …)`), so the value is `F23`, not a triplet.
- Durability: `KServiceActionComponent::writeSettings()` only drops the entry when the configured shortcut equals the desktop file's default (`X-KDE-Shortcuts`). We deliberately do *not* set `X-KDE-Shortcuts`, so `F23` differs from the (empty) default and KDE re-persists it on every rewrite instead of reverting it.

`ini_file` has no nested-group syntax, hence the `section: "services][{{ home_claude_launcher_file }}"` spelling; a short comment in the task records that, with the full derivation kept here rather than in the source.

**Launcher basename var (`roles/home/vars/main.yml`, commit c248670)** — the basename is load-bearing twice (kglobalacceld resolves the shortcut to the launcher *by filename*, so the `dest:` of the template task and the `section:` of the binding task must stay byte-identical). Both now read `home_claude_launcher_file` instead of independent literals, following the role's existing `home_gitidentity_file` convention (var + warning comment for cross-file couplings that fail silently). Answers `settling/F1`.

**Launcher entry (`roles/home/templates/hanzo-claude-code.desktop.j2`)** — `Exec=ghostty --working-directory={{ ansible_facts.env.HOME }}/cowork -e fish -c claude`. `%h` is not a Desktop Entry field code (only `%f %F %u %U %i %c %k`), so the home path is templated in. `agents` is dropped. `claude` is an npm global under the fnm-managed Node version and is only on PATH once the shell environment loads (dotfiles `conf.d/environment.fish`, sourced by fish for every session kind); a desktop activation inherits the session environment, which has no fnm PATH entry — hence `fish -c claude` rather than a bare `claude`. `Comment` is unchanged.

### Testing:

**Lint** — `pre-commit run --all-files`: all hooks pass (ansible-lint included).

**Full container check** — `docker build -f tests/Containerfile -t hanzo:test .`: passes, `failed=0`. EC-1 confirmed — on the non-KDE container the binding task reports `skipping: [localhost]`, and the rendered entry is:

```
TASK [home : Deploy Claude Code launcher .desktop entry] ***********************
+Exec=ghostty --working-directory=/home/testuser/cowork -e fish -c claude
TASK [home : Bind Copilot key (F23) to Claude Code launcher in KDE] ************
skipping: [localhost]
```

**AC-2 — spec-valid Exec** (`desktop-file-validate`, in-container):

```
$ desktop-file-validate hanzo-claude-code.desktop        # new entry
(no errors; one "more than one main category" hint, pre-existing)
$ desktop-file-validate old.desktop                      # entry as on main
error: value "ghostty --working-directory=%h/cowork -e claude agents" for key "Exec"
       in group "Desktop Entry" contains an invalid field code "%h"
exit=1
```

**AC-3 — idempotency of the binding task** (module-level, in-container):

```
run 1: localhost | CHANGED => { "changed": true,
run 2: localhost | SUCCESS => { "changed": false,
file:  [services][hanzo-claude-code.desktop]
       _launch=F23
```

**EC-3 — operator rebound F23 elsewhere**: seeding `_launch=Meta+X` and re-running the task reports `"changed": true` and restores `_launch=F23`.

**EC-2 — fresh KDE home, no existing KDE config, no active session** (in-container, `HOME` with no `.config` directory at all; task parameters taken from the role, role vars loaded so both use sites render from `home_claude_launcher_file`):

```
--- fresh HOME, no ~/.config:
=== EC-2 run 1 (fresh home) ===
    "msg": [
        "dest:    /tmp/ec2home/.local/share/applications/hanzo-claude-code.desktop",
        "section: services][hanzo-claude-code.desktop"
    ]
TASK [Bind Copilot key (F23) to Claude Code launcher in KDE] *******************
changed: [localhost]
localhost : ok=3  changed=1  unreachable=0  failed=0
=== EC-2 run 2 (idempotency) ===
localhost : ok=3  changed=0  unreachable=0  failed=0
=== resulting file ===
drwxr-xr-x 1 testuser testuser 36 /tmp/ec2home/.config
-rw-r--r-- 1 testuser testuser 51 /tmp/ec2home/.config/kglobalshortcutsrc

[services][hanzo-claude-code.desktop]
_launch=F23
```

`ini_file` creates the missing `~/.config` parent itself, so the first run on a fresh home succeeds and the binding is on disk for the next login. The same run is the evidence that the two use sites of `home_claude_launcher_file` render identically.

**AC-1 / AC-4 / AC-5 — on-device, for the operator** (not claimed here; the spec's proof channel for these is on-device demonstration, which cannot be produced from CI or the container — these boxes are the merge gate):

- [ ] Run `hanzo` on the GZ302, then log out and back in to KDE once.
- [ ] **AC-1** — press the Copilot key: a Ghostty window opens.
- [ ] **AC-5** — in that window, `pwd` is `~/cowork` and `claude` is running.
- [ ] **AC-4** — log out and back in again; the key still launches.

If the AC-5 step fails with `claude: command not found`, the fnm PATH assumption in the `Exec` line needs revisiting — report the exact error.

Optional check without a logout: `grep -A1 'services\]\[hanzo-claude-code.desktop' ~/.config/kglobalshortcutsrc` should show `_launch=F23`.

### Extra Notes (optional):

Review focus: the `section: "services][{{ home_claude_launcher_file }}"` spelling in `roles/home/tasks/kde.yml` (it looks like a typo but is the only way `ini_file` can express a KConfig nested group), and the `fish -c` wrapper in the Exec line.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`


