### PR TITLE
fix(system): replace initramfs handler with convergent rebuild task (#293)

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -8,6 +8,10 @@
     - "!all"
     - min
     - hardware
+  # Handlers flush at the end of the play, so without this a failure in any
+  # later role silently drops pending notifications that idempotent tasks
+  # will never re-send (issue #293).
+  force_handlers: true
 
   vars:
     # Transient sudoers drop-in granting NOPASSWD: /usr/bin/pacman
@@ -151,11 +155,3 @@
             state: absent
           become: true
           tags: [always]
-
-  # Regenerates the initramfs for every installed kernel and rewrites the
-  # Limine boot entries from /etc/default/limine.
-  handlers:
-    - name: Regenerate initramfs
-      ansible.builtin.command: limine-mkinitcpio
-      changed_when: true
-      become: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,9 +8,8 @@
     - "!all"
     - min
     - hardware
-  # Handlers flush at the end of the play, so without this a failure in any
-  # later role silently drops pending notifications that idempotent tasks
-  # will never re-send (issue #293).
+  # Handlers flush at the end of the play, so a failure in a later role would
+  # otherwise drop pending notifications that idempotent tasks never re-send.
   force_handlers: true
 
   vars:

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -47,7 +47,6 @@
     dest: /etc/modprobe.d/amdgpu.conf
     mode: "0644"
   become: true
-  notify: Regenerate initramfs
 
 - name: Ensure OLED kernel param in Limine cmdline
   ansible.builtin.lineinfile:
@@ -55,7 +54,6 @@
     regexp: '^KERNEL_CMDLINE\[default\]\+=" amdgpu\.dcdebugmask='
     line: 'KERNEL_CMDLINE[default]+=" {{ hardware_gz302_oled_kernel_param }}"'
   become: true
-  notify: Regenerate initramfs
 
 - name: Deploy suspend/resume hook
   ansible.builtin.template:

--- a/roles/system/tasks/hibernate.yml
+++ b/roles/system/tasks/hibernate.yml
@@ -7,15 +7,14 @@
 # https://wiki.cachyos.org/configuration/general_system_tweaks/#swap-configuration
 
 # Kernel params live in /etc/default/limine; limine-mkinitcpio regenerates
-# the boot entries and the initramfs from it, so both param tasks and the
-# mkinitcpio drop-in below share the same handler.
+# the boot entries and the initramfs from it — that rebuild runs
+# unconditionally at the end of the role (tasks/main.yml), not via handler.
 - name: Ensure ZRam is disabled in Limine cmdline
   ansible.builtin.lineinfile:
     path: /etc/default/limine
     regexp: '^KERNEL_CMDLINE\[default\]\+=" systemd\.zram='
     line: 'KERNEL_CMDLINE[default]+=" {{ system_zram_kernel_param }}"'
   become: true
-  notify: Regenerate initramfs
 
 - name: Ensure Zswap kernel params in Limine cmdline
   ansible.builtin.lineinfile:
@@ -23,7 +22,6 @@
     regexp: '^KERNEL_CMDLINE\[default\]\+=" zswap\.'
     line: 'KERNEL_CMDLINE[default]+=" {{ system_zswap_kernel_params }}"'
   become: true
-  notify: Regenerate initramfs
 
 # /usr/lib/udev/rules.d/30-zram.rules (cachyos-settings) writes `N` to
 # /sys/module/zswap/parameters/enabled whenever zram0 changes state. A
@@ -89,7 +87,6 @@
     group: root
     mode: "0644"
   become: true
-  notify: Regenerate initramfs
 
 # systemd ships sleep.conf and logind.conf, but not their .conf.d/
 # drop-in directories — ansible.builtin.copy does not create parent

--- a/roles/system/tasks/hibernate.yml
+++ b/roles/system/tasks/hibernate.yml
@@ -6,9 +6,8 @@
 # the CachyOS wiki "Switching from ZRam to Zswap" procedure:
 # https://wiki.cachyos.org/configuration/general_system_tweaks/#swap-configuration
 
-# Kernel params live in /etc/default/limine; limine-mkinitcpio regenerates
-# the boot entries and the initramfs from it — that rebuild runs
-# unconditionally at the end of the role (tasks/main.yml), not via handler.
+# Kernel params live in /etc/default/limine; the rebuild that applies them
+# runs at the end of the role (tasks/main.yml), not via handler.
 - name: Ensure ZRam is disabled in Limine cmdline
   ansible.builtin.lineinfile:
     path: /etc/default/limine

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -24,12 +24,16 @@
   ansible.builtin.include_tasks: hibernate.yml
   when: host_has_systemd
 
-# Rebuilt unconditionally, last in the role (tagged `always`, imported
-# after `hardware`), because a handler notification is consumed by a single
-# run: lost or failed once, it is never re-sent and the boot artifacts stay
-# stale forever while every run reports clean (issue #293).
+# Runs on every invocation, last in the role, because a handler notification
+# is consumed once: lost or failed, it is never re-sent (issue #293).
 - name: Regenerate initramfs and Limine boot entries
   ansible.builtin.command: limine-mkinitcpio
+  register: system_limine_rebuild
   changed_when: true
+  # limine-mkinitcpio swallows per-kernel failures and still exits 0, printing
+  # `ERROR:` to stderr — rc alone would report a stale initramfs as success.
+  failed_when: >-
+    system_limine_rebuild.rc != 0
+    or 'ERROR:' in system_limine_rebuild.stderr
   when: host_has_systemd
   become: true

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -23,3 +23,13 @@
 - name: Configure hibernation
   ansible.builtin.include_tasks: hibernate.yml
   when: host_has_systemd
+
+# Rebuilt unconditionally, last in the role (tagged `always`, imported
+# after `hardware`), because a handler notification is consumed by a single
+# run: lost or failed once, it is never re-sent and the boot artifacts stay
+# stale forever while every run reports clean (issue #293).
+- name: Regenerate initramfs and Limine boot entries
+  ansible.builtin.command: limine-mkinitcpio
+  changed_when: true
+  when: host_has_systemd
+  become: true


### PR DESCRIPTION
**Claude Harness**

Makes the initramfs / Limine rebuild convergent. The play-level `Regenerate initramfs` handler and its five `notify` lines are deleted; `limine-mkinitcpio` now runs unconditionally as the last task of the `system` role (tagged `always`, imported after `hardware`, gated on `host_has_systemd`). Handler notification state is consumed by a single run — lost when a later role fails before handlers flush, or spent by a rebuild that itself failed — and the idempotent config tasks never re-send it, so the boot artifacts could stay stale forever while every run reported clean. `force_handlers: true` is added on the play as hardening for the remaining service handlers (`Restart keyd`, `Reload logind`).

## Run record

- **Issue:** #293
- **Type:** change — confirmed at `/deliver`
- **Session:** `4a602ac4-4426-4869-93e7-67c017f63d2d` — resume with `claude --resume 4a602ac4-4426-4869-93e7-67c017f63d2d`

Closes #293
