### PR TITLE
ci: pin actions/checkout and actions/setup-python at latest releases by SHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build test container
         run: docker build -f tests/Containerfile -t hanzo:test .


### PR DESCRIPTION
Bumps the SHA-pinned GitHub Actions in `.github/workflows/test.yaml` to their current latest releases:

- `actions/checkout`: v4.2.2 -> v7.0.1 (`3d3c42e5aac5ba805825da76410c181273ba90b1`)
- `actions/setup-python`: v5.6.0 -> v7.0.0 (`5fda3b95a4ea91299a34e894583c3862153e4b97`)

Tag SHAs verified via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` — both refs resolve directly to the commits above. The `# vX.Y.Z` comment style is preserved on every occurrence.

Test evidence: `pre-commit run --files .github/workflows/test.yaml` passes (check yaml, ansible-lint, whitespace hooks all green). Workflow-only change, no container build required.