### PR TITLE
feat(desktop): install qrca from extra via pacman

### DIFF
--- a/roles/desktop/vars/main.yml
+++ b/roles/desktop/vars/main.yml
@@ -12,13 +12,13 @@ desktop_pacman:
   - ghostty
   - wl-clipboard
   - plasma-keyboard
+  - qrca
 
 desktop_aur:
   - google-chrome
   - wifiman-desktop
   - zoom
   - darkly
-  - qrca
 
 desktop_user_groups:
   - video


### PR DESCRIPTION
qrca is now available in the Arch `extra` repository (verified: `pacman -Si qrca` resolves to `extra/qrca 26.04.3-1` in `cachyos/cachyos:latest`, and it is not explicit in the base image per `pacman -Qe`), so it no longer needs to be built from the AUR.

## What changed

- `roles/desktop/vars/main.yml`: moved `qrca` from `desktop_aur` to `desktop_pacman`. The `kewlfft.aur.aur` task in the desktop role is unchanged — other AUR packages still use it.

## Test evidence

- `pre-commit run --files roles/desktop/vars/main.yml`: all hooks passed (ansible-lint, yaml, whitespace).
- `docker build -f tests/Containerfile -t hanzo:split-qrca .`: exit 0 — `bootstrap`-equivalent `ansible-playbook playbook.yml --check --diff` completed inside the CachyOS container.
