### PR TITLE
feat(security)!: drop proton-vpn-gtk-app in favor of manual WireGuard

### DIFF
--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -4,11 +4,6 @@
 # key is seeded by roles/trust, which playbook.yml runs before this
 # role.
 
-- name: Install security pacman packages
-  community.general.pacman:
-    name: "{{ security_pacman }}"
-  become: true
-
 # kewlfft.aur.aur batches the list under `name:` into a single paru
 # invocation. paru must run as the unprivileged user — it refuses root.
 - name: Install security AUR packages

--- a/roles/security/vars/main.yml
+++ b/roles/security/vars/main.yml
@@ -1,9 +1,8 @@
 ---
-# Security tooling. VPN uses WireGuard directly, configured manually
-# post-install — no VPN client package. 1Password (GUI + CLI) is
-# AUR-only and depends on the AgileBits GPG key seeded by roles/trust —
-# playbook.yml orders trust before security, and trust is tagged
-# `always` so any --tags security run still imports the key first.
+# Security tooling. 1Password (GUI + CLI) is AUR-only and depends on
+# the AgileBits GPG key seeded by roles/trust — playbook.yml orders
+# trust before security, and trust is tagged `always` so any --tags
+# security run still imports the key first.
 security_aur:
   - 1password
   - 1password-cli

--- a/roles/security/vars/main.yml
+++ b/roles/security/vars/main.yml
@@ -1,12 +1,9 @@
 ---
-# Security tooling. Proton VPN ships via pacman; 1Password (GUI + CLI)
-# is AUR-only and depends on the AgileBits GPG key seeded by
-# roles/trust — playbook.yml orders trust before security, and trust is
-# tagged `always` so any --tags security run still imports the key
-# first.
-security_pacman:
-  - proton-vpn-gtk-app
-
+# Security tooling. VPN uses WireGuard directly, configured manually
+# post-install — no VPN client package. 1Password (GUI + CLI) is
+# AUR-only and depends on the AgileBits GPG key seeded by roles/trust —
+# playbook.yml orders trust before security, and trust is tagged
+# `always` so any --tags security run still imports the key first.
 security_aur:
   - 1password
   - 1password-cli


### PR DESCRIPTION
## What changed

- `roles/security/vars/main.yml`: removed `proton-vpn-gtk-app`; the list became empty, so `security_pacman` is gone entirely. Header comment now states that VPN uses WireGuard directly, configured manually post-install.
- `roles/security/tasks/main.yml`: removed the now-orphaned pacman install task. The AUR task (1Password) is untouched.
- `bin/bootstrap.sh`: left unchanged — on main it ends with `exec hanzo`, so there is no post-provisioning point where a WireGuard setup pointer could print without altering the exec semantics.

## Why

The Proton VPN GTK client is no longer wanted; VPN connectivity is WireGuard configured manually after install, so the provisioner declares no VPN client package.

## Test evidence

- `pre-commit run --files roles/security/vars/main.yml roles/security/tasks/main.yml`: all hooks passed (ansible-lint included).
- `docker build -f tests/Containerfile -t hanzo:split-vpn .`: exit 0 — PLAY RECAP `ok=60 changed=30 failed=0`, image exported.
- `grep -rn 'security_pacman\|proton' roles/ playbook.yml`: no matches remain.