### PR TITLE
feat(languages): install fnm from extra via pacman

### DIFF
--- a/roles/languages/tasks/node.yml
+++ b/roles/languages/tasks/node.yml
@@ -1,9 +1,8 @@
 ---
-- name: Install Node.js AUR packages
-  kewlfft.aur.aur:
+- name: Install Node.js packages
+  community.general.pacman:
     name: "{{ languages_node_packages }}"
-    use: paru
-  become: false
+  become: true
 
 # Each shell task runs in a fresh process, so we must eval fnm env to
 # activate it. fnm install is idempotent (skips installed versions) —

--- a/roles/languages/vars/main.yml
+++ b/roles/languages/vars/main.yml
@@ -9,6 +9,6 @@ languages_go_packages:
   - go
 
 languages_node_packages:
-  - fnm-bin
+  - fnm
 
 languages_gopath: ~/.golang


### PR DESCRIPTION
fnm moved from AUR (fnm-bin) to the Arch extra repository: verified via pacman -Si fnm on cachyos/cachyos:latest (extra/fnm) and absent from the base image explicit set.

- roles/languages/vars/main.yml: languages_node_packages fnm-bin -> fnm
- roles/languages/tasks/node.yml: kewlfft.aur.aur/paru task replaced with community.general.pacman, become: true

The fnm LTS bootstrap task is untouched. CI runs lint, playbook --check, and full e2e provisioning on this PR.