### PR TITLE
refactor(cli): extract shared bash utilities into bin/lib.sh

### DIFF
--- a/bin/hanzo
+++ b/bin/hanzo
@@ -7,11 +7,11 @@
 
 set -euo pipefail
 
-GREEN='\033[0;32m'
-NC='\033[0m'
-log_info() { echo -e "${GREEN}[hanzo]${NC} $1"; }
-
 HANZO_DIR="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
+
+# shellcheck source=bin/lib.sh
+source "$HANZO_DIR/bin/lib.sh"
+
 HANZO_AUR_SUDOERS="/etc/sudoers.d/hanzo-aur"
 
 # Belt-and-suspenders cleanup. Ansible's block/always inside

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# Shared utilities for hanzo bin/ scripts. Source it, don't execute it.
+
+# shellcheck disable=SC2034  # consumers pick the colors they need
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+HANZO_LOG_PREFIX="${HANZO_LOG_PREFIX:-hanzo}"
+
+log_info()  { echo -e "${GREEN}[${HANZO_LOG_PREFIX}]${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}[${HANZO_LOG_PREFIX}]${NC} $1"; }
+log_error() { echo -e "${RED}[${HANZO_LOG_PREFIX}]${NC} $1" >&2; }
+
+# True when a controlling terminal is available for prompts.
+has_tty() { { : </dev/tty; } 2>/dev/null; }
+
+# True when running inside a container (podman, docker, or generic).
+in_container() {
+    [ -f /run/.containerenv ] || [ -f /.dockerenv ] || \
+        grep -qa 'container=' /proc/1/environ 2>/dev/null
+}
+
+# Parses at most one mode flag into HANZO_MODE: --check, --ci, or none (full).
+# Anything else is a usage error.
+parse_mode() {
+    HANZO_MODE="full"
+    if [ "$#" -eq 0 ]; then
+        return 0
+    fi
+    if [ "$#" -eq 1 ]; then
+        case "$1" in
+            --check) HANZO_MODE="check"; return 0 ;;
+            --ci)    HANZO_MODE="ci";    return 0 ;;
+        esac
+    fi
+    log_error "invalid arguments: $*"
+    log_error "usage: ${0##*/} [--check|--ci]"
+    exit 1
+}
+
+# Announces any non-default HANZO_MODE; new modes only add a description line.
+mode_banner() {
+    local label desc
+    case "${HANZO_MODE:-full}" in
+        check) label="CHECK"; desc="dry run — reports changes without applying them" ;;
+        ci)    label="CI";    desc="unattended provisioning — human AUR verification is bypassed" ;;
+        *)     return 0 ;;
+    esac
+    echo -e "${YELLOW}>>> ${label} MODE — ${desc}${NC}"
+}


### PR DESCRIPTION
## Summary

Pure extraction, no behavior change: shared bash helpers (colors, `log_info`/`log_warn`/`log_error` with a configurable `HANZO_LOG_PREFIX`, `has_tty`, `in_container`, `parse_mode`, `mode_banner`) move into a new sourced `bin/lib.sh`, and `bin/hanzo` drops its inline duplicates and sources it.

Decision: `bin/bootstrap.sh` is curl-piped and runs before the repo clone exists, so it keeps its inline color/log definitions entirely — only repo-resident scripts source `lib.sh`.

`parse_mode`, `mode_banner`, `has_tty`, and `in_container` are unused here by design; the provisioning-modes PR stacked on this one adopts them.

## Testing

- `pre-commit run --all-files` green (shellcheck, ansible-lint, generic hooks)
- `docker build -f tests/Containerfile -t hanzo:lib-check .` green (exit 0)
- Sourced-library smoke test: log prefix override, mode parsing (none/--check/--ci/unknown/extra args), banner output