### PR TITLE
chore(lint): update and expand pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,29 @@
 fail_fast: true
 
+default_install_hook_types:
+    - pre-commit
+    - commit-msg
+
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v6.0.0
       hooks:
+          - id: check-added-large-files
+          - id: check-case-conflict
+          - id: check-executables-have-shebangs
           - id: check-json
           - id: check-merge-conflict
+          - id: check-shebang-scripts-are-executable
+            # Deployed with mode 0755 by ansible.builtin.template; not executable in-tree.
+            exclude: ^roles/hardware/templates/.*\.j2$
+          - id: check-symlinks
           - id: check-toml
+          - id: check-vcs-permalinks
           - id: check-yaml
+          - id: destroyed-symlinks
+          - id: detect-private-key
           - id: end-of-file-fixer
+          - id: forbid-new-submodules
           - id: mixed-line-ending
           - id: trailing-whitespace
 
@@ -21,3 +36,24 @@ repos:
       rev: v26.8.0
       hooks:
           - id: ansible-lint
+
+    - repo: https://github.com/gitleaks/gitleaks
+      rev: v8.30.0
+      hooks:
+          - id: gitleaks
+
+    - repo: https://github.com/rhysd/actionlint
+      rev: v1.7.12
+      hooks:
+          - id: actionlint
+
+    - repo: https://github.com/codespell-project/codespell
+      rev: v2.4.3
+      hooks:
+          - id: codespell
+
+    - repo: https://github.com/compilerla/conventional-pre-commit
+      rev: v4.4.0
+      hooks:
+          - id: conventional-pre-commit
+            stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ fail_fast: true
 
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v5.0.0
+      rev: v6.0.0
       hooks:
           - id: check-json
           - id: check-merge-conflict
@@ -18,6 +18,6 @@ repos:
           - id: shellcheck
 
     - repo: https://github.com/ansible/ansible-lint
-      rev: v26.4.0
+      rev: v26.8.0
       hooks:
           - id: ansible-lint


### PR DESCRIPTION
## Summary

Two commits:

**1. `pre-commit autoupdate` on existing hooks**
- `pre-commit/pre-commit-hooks`: v5.0.0 → v6.0.0
- `ansible/ansible-lint`: v26.4.0 → v26.8.0
- `shellcheck-py/shellcheck-py`: already up to date (v0.11.0.1)

**2. New code-quality hooks** (selected from a repo survey; all dry-run against the current tree)
- `gitleaks` (v8.30.0) — hardcoded-secret scanning; verified zero false positives on the legit GPG fingerprint and sha256 hashes in `roles/trust/vars/main.yml`
- `actionlint` (v1.7.12) — lints `.github/workflows`, which ansible-lint's embedded yamllint never touches
- `codespell` (v2.4.3) — typo detection for the prose-heavy comments/docs
- `conventional-pre-commit` (v4.4.0, `commit-msg` stage) — enforces the Conventional Commits rule already in CLAUDE.md; `default_install_hook_types` added so a plain `pre-commit install` activates it. **Existing checkouts must re-run `pre-commit install` once.**
- Additional ids from the already-pinned `pre-commit-hooks` repo: `check-added-large-files`, `check-case-conflict`, `check-executables-have-shebangs`, `check-shebang-scripts-are-executable` (with `exclude` for `roles/hardware/templates/*.j2`, which is intentionally non-executable in-tree and deployed with mode 0755 by `ansible.builtin.template`), `check-symlinks`, `check-vcs-permalinks`, `destroyed-symlinks`, `detect-private-key`, `forbid-new-submodules`

Evaluated and deliberately **not** added: `detect-secrets` (3 false positives where gitleaks had none), `yamllint` (ansible-lint already lints all Ansible YAML; only 2 files fall outside its scope), `hadolint` (both Containerfile findings are intentional: rolling-release `latest` tag, forced `--platform=linux/amd64`), `shfmt` (would rewrite the intentional compact `log()`/`fail()` helpers), `markdownlint` (3 files, heavy rule suppression needed), YAML formatters (conflict with this config's 4-space style), `no-commit-to-branch` (server-side branch protection already covers it).

## Testing

- `pre-commit autoupdate` run after adding the new hooks; all revs are latest.
- `pre-commit run --all-files` passes (21 hooks green).
- `conventional-pre-commit` verified at the `commit-msg` stage: accepts `chore(lint): ...`, rejects `made some changes`.
- Container test not run: only `.pre-commit-config.yaml` changed; `tests/Containerfile` does not use pre-commit, so provisioning is unaffected.