### PR TITLE
ci: split workflows by concern; run full --ci provisioning every Friday

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: CI
 
 on:
   workflow_dispatch:
@@ -6,12 +6,18 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    - cron: '0 2 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -27,11 +33,12 @@ jobs:
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
 
-  test:
+  check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Build test container
+      - name: Provisioning check (dry run)
         run: docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,25 @@
+name: Weekly Full Provision
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Friday 02:17 UTC — off the top of the hour, when GitHub's scheduler
+    # is most congested and cron runs get delayed or dropped.
+    - cron: '17 2 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    # Real provisioning compiles AUR packages from source; the generous
+    # cap absorbs slow builds while still catching hangs well before the
+    # 6-hour runner default.
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Full unattended provisioning
+        run: docker build --build-arg HANZO_ARGS="--ci" -f tests/Containerfile -t hanzo:test .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ The container provisions through `bin/bootstrap.sh`, exactly as a production mac
 
 - `pre-commit run --all-files`: Lint all files (ansible-lint, shellcheck, generic hooks).
 - `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .`: Provisioning check (dry run, what CI runs).
-- `docker build --build-arg HANZO_ARGS="--ci" -f tests/Containerfile -t hanzo:test .`: Full unattended provisioning.
+- `docker build --build-arg HANZO_ARGS="--ci" -f tests/Containerfile -t hanzo:test .`: Full unattended provisioning (what the weekly cron runs).
 
 ## Role Tags
 
@@ -49,5 +49,5 @@ All testing goes through the CachyOS container — see the Commands section abov
 Before submitting changes:
 
 - [ ] Lint passes: `pre-commit run --all-files`
-- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`
+- [ ] Container test passes: `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .`
 - [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hanzo
 
-[![Testing](https://github.com/palazzem/hanzo/actions/workflows/test.yaml/badge.svg)](https://github.com/palazzem/hanzo/actions/workflows/test.yaml)
+[![CI](https://github.com/palazzem/hanzo/actions/workflows/ci.yml/badge.svg)](https://github.com/palazzem/hanzo/actions/workflows/ci.yml)
 
 > Hattori Hanzō: You must have big rats if you need Hattori Hanzo's steel.
 > The Bride: ...Huge.


### PR DESCRIPTION
## Summary

Reworks GitHub Actions per current best practices (workflows split by trigger/concern, not by task):

- **`ci.yml`** (`CI`) — runs on `pull_request`, `push` to `main`, and `workflow_dispatch`. Jobs: `lint` (pre-commit) and `check` (container build with `HANZO_ARGS="--check"`). Adds a `concurrency` group that cancels superseded PR runs, an explicit `permissions: contents: read` block, and per-job `timeout-minutes`.
- **`weekly.yml`** (`Weekly Full Provision`) — replaces the old Monday cron (which only re-ran the dry run) with a **Friday** schedule running a **full unattended `--ci` provisioning** in the container, plus `workflow_dispatch` for on-demand runs. Cron fires at 02:17 UTC — off the top of the hour, where GitHub's scheduler is most congested. No `cancel-in-progress`: a real provisioning run always finishes.
- Removes `test.yaml`; updates the README badge to `ci.yml`.
- Fixes the stale container command in CLAUDE.md's checklist (`HANZO_ARGS` is required since #313) and notes that `--ci` is what the weekly cron runs.

## Notes

- **Required status checks**: if branch protection requires `Testing / lint` or `Testing / test`, those need updating to `CI / lint` and `CI / check` after merge.
- Scheduled workflows in public repos are auto-disabled after 60 days without repo activity; routine pushes/merges reset the clock.

## Testing

- `pre-commit run --all-files` passes.
- `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .` (the exact command `ci.yml` runs).