### PR TITLE
chore(deps): freeze pre-commit hooks to SHAs and pin CI toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing after checkout talks to GitHub; don't leave a token in .git/config.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -28,7 +31,8 @@ jobs:
           python-version: "3.14"
 
       - name: Install pre-commit
-        run: pip install pre-commit
+        # Pinned so a pre-commit release can't change lint results mid-PR.
+        run: pip install pre-commit==4.6.2
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
@@ -39,6 +43,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The container build only reads the copied tree; no token needed.
+          persist-credentials: false
 
       - name: Provisioning check (dry run)
         run: docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The container build only reads the copied tree; no token needed.
+          persist-credentials: false
 
       - name: Full unattended provisioning
         run: docker build --build-arg HANZO_ARGS="--ci" -f tests/Containerfile -t hanzo:test .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_install_hook_types:
 
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v6.0.0
+      rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
       hooks:
           - id: check-added-large-files
           - id: check-case-conflict
@@ -28,32 +28,32 @@ repos:
           - id: trailing-whitespace
 
     - repo: https://github.com/shellcheck-py/shellcheck-py
-      rev: v0.11.0.1
+      rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1
       hooks:
           - id: shellcheck
 
     - repo: https://github.com/ansible/ansible-lint
-      rev: v26.8.0
+      rev: 665d9e07a1943254d2910faffc106adaf7ea7294  # frozen: v26.8.0
       hooks:
           - id: ansible-lint
 
     - repo: https://github.com/gitleaks/gitleaks
-      rev: v8.30.0
+      rev: 2ca41cc1372d1e939a6a879f18cdc19fc1cac1ce  # frozen: v8.30.0
       hooks:
           - id: gitleaks
 
     - repo: https://github.com/rhysd/actionlint
-      rev: v1.7.12
+      rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
       hooks:
           - id: actionlint
 
     - repo: https://github.com/codespell-project/codespell
-      rev: v2.4.3
+      rev: 57b21406f092110c18776e39b0bda50d37c945c8  # frozen: v2.4.3
       hooks:
           - id: codespell
 
     - repo: https://github.com/compilerla/conventional-pre-commit
-      rev: v4.4.0
+      rev: 3db014c16a9d31997ab8c07a4d61fcce936c8f0d  # frozen: v4.4.0
       hooks:
           - id: conventional-pre-commit
             stages: [commit-msg]


### PR DESCRIPTION
## What changed

**1. Every pre-commit hook rev frozen to a commit SHA** (`pre-commit autoupdate --freeze`). Each `rev:` is now an immutable SHA with the human-readable version preserved as a `# frozen: vX.Y.Z` comment. No hook version changed — this is purely tag → SHA:

| repo | rev |
| --- | --- |
| pre-commit-hooks | `3e8a870` (v6.0.0) |
| shellcheck-py | `745eface` (v0.11.0.1) |
| ansible-lint | `665d9e07` (v26.8.0) |
| gitleaks | `2ca41cc1` (v8.30.0) |
| actionlint | `914e7df2` (v1.7.12) |
| codespell | `57b21406` (v2.4.3) |
| conventional-pre-commit | `3db014c1` (v4.4.0) |

**2. `pre-commit` pinned in CI** — `pip install pre-commit==4.6.2` (current latest on PyPI), so a pre-commit release can't shift lint results between a green PR run and a rerun on main.

**3. `persist-credentials: false` on all three checkout steps** (both jobs in `ci.yml`, the one job in `weekly.yml`). Nothing after checkout talks to GitHub: `bin/hanzo` never fetches in `--check`/`--ci` mode, and the container build only reads the tree copied by `tests/Containerfile`. Dropping the token from `.git/config` removes it from anything the lint hooks or the container build can reach.

## Why

Git tags are mutable. A retagged upstream silently changes what runs in CI, which is exactly the supply-chain step this repo already guards against for GitHub Actions (all `uses:` are already SHA-pinned with version comments) — the pre-commit hooks and the CI toolchain were the remaining unpinned surface.

## Verification

```
$ pre-commit autoupdate --freeze
[https://github.com/pre-commit/pre-commit-hooks] updating v6.0.0 -> v6.0.0 (frozen)
[https://github.com/shellcheck-py/shellcheck-py] updating v0.11.0.1 -> v0.11.0.1 (frozen)
[https://github.com/ansible/ansible-lint] updating v26.8.0 -> v26.8.0 (frozen)
[https://github.com/gitleaks/gitleaks] updating v8.30.0 -> v8.30.0 (frozen)
[https://github.com/rhysd/actionlint] updating v1.7.12 -> v1.7.12 (frozen)
[https://github.com/codespell-project/codespell] updating v2.4.3 -> v2.4.3 (frozen)
[https://github.com/compilerla/conventional-pre-commit] updating v4.4.0 -> v4.4.0 (frozen)

$ pre-commit run --all-files
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check that executables have shebangs.....................................Passed
check json...............................................................Passed
check for merge conflicts................................................Passed
check that scripts with shebangs are executable..........................Passed
check for broken symlinks............................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check vcs permalinks.....................................................Passed
check yaml...............................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
forbid new submodules................................(no files to check)Skipped
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
shellcheck...............................................................Passed
ansible-lint.............................................................Passed
Detect hardcoded secrets.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
codespell................................................................Passed
```

actionlint (run via pre-commit) accepts both workflows after the `persist-credentials` additions.

## Caveats

- No container build was run for this PR — it touches only lint config and workflow metadata, no playbook, role, or `bin/` code. The `check` job on this PR exercises `docker build --build-arg HANZO_ARGS="--check"` in CI.
- Frozen revs make `pre-commit autoupdate` (unfrozen) a no-go from here on: future updates must keep the `--freeze` flag or the SHAs revert to tags.
- `pre-commit==4.6.2` now needs a bump alongside hook updates; it will not drift on its own.
