### PR TITLE
feat(languages): install pyenv from extra instead of pyenv.run

### DIFF
--- a/roles/languages/tasks/python.yml
+++ b/roles/languages/tasks/python.yml
@@ -3,23 +3,3 @@
   community.general.pacman:
     name: "{{ languages_python_packages }}"
   become: true
-
-# Download + execute is split (vs. curl | bash) to avoid risky-shell-pipe
-# and to get idempotency via creates: on the execute step. Cache lives
-# under $HOME (mode 0700) to avoid /tmp symlink-race surface and
-# shared-/tmp visibility on multi-user systems.
-- name: Download pyenv installer
-  ansible.builtin.get_url:
-    url: https://pyenv.run
-    dest: "{{ ansible_facts.env.HOME }}/.cache/hanzo/pyenv-installer.sh"
-    mode: "0700"
-  become: false
-
-# Skipped in check mode: get_url doesn't actually download the file in
-# check mode, so the installer script isn't on disk to execute.
-- name: Install pyenv via pyenv-installer
-  ansible.builtin.command:
-    cmd: "{{ ansible_facts.env.HOME }}/.cache/hanzo/pyenv-installer.sh"
-    creates: "{{ ansible_facts.env.HOME }}/.pyenv/bin/pyenv"
-  when: not ansible_check_mode
-  become: false

--- a/roles/languages/vars/main.yml
+++ b/roles/languages/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 languages_python_packages:
+  - pyenv
   - uv
 
 languages_rust_packages:


### PR DESCRIPTION
## What changed

- `roles/languages/vars/main.yml`: added `pyenv` to `languages_python_packages`.
- `roles/languages/tasks/python.yml`: removed the `Download pyenv installer` and `Install pyenv via pyenv-installer` tasks (and their comments). The file is now a single pacman task.

## Why

`https://pyenv.run` was fetched unpinned and with no checksum, then executed; the installer additionally `git clone`s its plugin repositories at `HEAD`. Every provisioning run therefore executed whatever code those remotes happened to serve at that moment — an unverified remote-code-execution surface in the middle of the playbook.

`extra/pyenv` is a signed, versioned Arch package on the normal pacman update path (currently `1:2.8.4-1`), which removes that surface. The accepted trade-off is that pyenv.run's bundled plugins — `pyenv-virtualenv`, `pyenv-update`, `pyenv-doctor` — are no longer installed by provisioning.

## Migration note (existing hosts)

- **`~/.pyenv` is left untouched.** Nothing in this change deletes or moves it, so **installed Python versions are preserved**: the packaged pyenv defaults `PYENV_ROOT` to `${HOME}/.pyenv` when the variable is unset (verified in `/usr/share/pyenv/libexec/pyenv`, lines 58-59), so it reads the same versions directory the old install used.
- **`/usr/bin/pyenv` takes over** (a symlink to `/usr/share/pyenv/libexec/pyenv`). Caveat on ordering: if a shell init still puts `$PYENV_ROOT/bin` ahead of `/usr/bin` on `PATH`, the stale clone at `~/.pyenv/bin/pyenv` keeps winning — it will simply no longer be updated by provisioning. Removing `~/.pyenv/bin` from `PATH` (or the stale clone's git checkout) makes the packaged binary authoritative.
- **Plugins are gone.** Fresh machines get no `pyenv-virtualenv` / `pyenv-update` / `pyenv-doctor`. On already-provisioned hosts the directories under `~/.pyenv/plugins/` still exist and are still sourced by the packaged pyenv, but they are now unmanaged — nothing updates them.
- **Action:** check `palazzem/dotfiles` pyenv init for plugin assumptions — anything doing `pyenv virtualenv ...`, `pyenv activate`, `eval "$(pyenv virtualenv-init -)"`, or `pyenv update` will break on a fresh machine. `pyenv-virtualenv` is available as `aur/pyenv-virtualenv` if it is still wanted; per CLAUDE.md rule 7 that would belong in `bin/hanzo-aur`, not here.

## Verification

```
$ pre-commit run --all-files
...
shellcheck...............................................................Passed
ansible-lint.............................................................Passed
Detect hardcoded secrets.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
codespell................................................................Passed
```

```
$ docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test-pr06 .
...
PLAY RECAP *********************************************************************
localhost                  : ok=46   changed=23   unreachable=0    failed=0    skipped=27   rescued=0    ignored=0
...
naming to docker.io/library/hanzo:test-pr06 done
```

Because `--check` is a dry run, the pacman task does not prove the package name resolves, so that was confirmed separately inside the container:

```
$ docker run --rm hanzo:test-pr06 bash -lc "pacman -Si extra/pyenv | head -8"
Repository      : extra
Name            : pyenv
Version         : 1:2.8.4-1
Description     : Easily switch between multiple versions of Python
```

## Caveats

- Not exercised with `HANZO_ARGS="--ci"` (full unattended install); only the `--check` build required by the checklist was run.
- `~/.cache/hanzo` is still created by `roles/system` and still used by `roles/tools/tasks/cloud.yml` for the gcloud installer, so it is intentionally left alone. A stale `~/.cache/hanzo/pyenv-installer.sh` may linger on existing hosts; it is inert and not cleaned up here to keep this PR to the two files in scope.
