### PR TITLE
feat(bootstrap): install uv from the repos instead of curl | sh

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -44,7 +44,7 @@ echo ""
 
 if ! command -v uv >/dev/null 2>&1; then
     log "Installing uv..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    sudo pacman -S --needed --noconfirm uv
 fi
 
 if ! uv tool list 2>/dev/null | grep -q '^ansible-core'; then


### PR DESCRIPTION
## What changed

`bin/bootstrap.sh` no longer pipes the Astral installer. When `uv` is missing it now runs:

```sh
log "Installing uv via pacman..."
sudo pacman -S --needed --noconfirm uv
```

The `PATH="$HOME/.local/bin:$PATH"` export is unchanged — `uv tool install` (ansible-core) still lands there.

`README.md` quickstart: the sudo-password note moved from step 5 to step 1, since the first prompt now happens while installing uv.

## Why

The bootstrap installed uv from an unpinned `curl -LsSf https://astral.sh/uv/install.sh | sh`, while `roles/languages` (`vars/main.yml`) already installs `uv` via pacman. A provisioned machine therefore ended up with two uv installations from two different sources, and the bootstrap one came from an unverified remote script executed as-is. Standardizing on the repo package makes pacman the single source of truth and removes the remote-script execution from the bootstrap path.

`sudo` opens `/dev/tty` itself, so the password prompt still works under `curl … | bash` (the same reason the name/email prompts read from `/dev/tty`). In the test container `testuser` has NOPASSWD sudo, so the unattended path is unaffected.

## Verification

```
$ pre-commit run --all-files
...
shellcheck...............................................................Passed
ansible-lint.............................................................Passed
Detect hardcoded secrets.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
codespell................................................................Passed
```

```
$ docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test-pr07 .
#12 116.1 PLAY RECAP *********************************************************************
#12 116.1 localhost                  : ok=47   changed=23   unreachable=0    failed=0    skipped=28   rescued=0    ignored=0
#13 naming to docker.io/library/hanzo:test-pr07 done
#13 DONE 1.2s
```

The container image ships no `uv`, so the build exercises exactly this branch. Confirming the resulting install came from the repos:

```
$ docker run --rm hanzo:test-pr07 sh -c 'pacman -Qi uv | head -4; command -v uv; uv --version'
Installed From  : extra
Name            : uv
Version         : 0.12.5-1
/usr/sbin/uv
uv 0.12.5 (210d1f678 2026-08-14 x86_64-unknown-linux-gnu)
```

## Caveats

- uv's version is now whatever `extra` ships (0.12.5-1 today) instead of Astral's latest — intended, and consistent with `roles/languages`.
- `pacman -S` does not sync the package database first. On a host with a stale db this can fail with "target not found"; the normal CachyOS flow (and the container, which runs `pacman -Syu`) has a fresh db. Adding `-Sy` was deliberately avoided — a partial upgrade is worse than a clear error on Arch.
