### PR TITLE
feat(config): load user config namespaced with an explicit allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ hanzo_email: "your@email.com"
 
 Edit this file directly to update your settings. You can also set `HANZO_FULLNAME` and `HANZO_EMAIL` as environment variables for unattended provisioning (e.g., in containers) — the bootstrap script will write them to the config file in YAML form, escaping any embedded quotes or backslashes.
 
+The file is loaded into its own namespace and read through an allowlist: exactly `hanzo_fullname` and `hanzo_email` are used, and **any other key is ignored**. It is not a place to override playbook or role variables — since the file is user-writable, an unfiltered load would let anything with write access to your home directory inject variables into tasks that run as root. Both keys are optional; when one is missing, the matching git identity setting is simply skipped.
+
 ## Architecture
 
 Hanzo uses Ansible to provision the local machine via `ansible-playbook playbook.yml`. All operations are idempotent — running `hanzo` multiple times is safe and will only apply changes that are needed.

--- a/playbook.yml
+++ b/playbook.yml
@@ -62,10 +62,38 @@
       register: hanzo_config_stat
       tags: [always]
 
+    # Namespaced under `hanzo_user_config` so the file's keys never land
+    # in play scope directly: `~/.config/hanzo/config.yml` is
+    # user-writable, and an unfiltered load outranks role vars — a
+    # compromised account could plant `system_packages` and have a
+    # `become: true` task install it as root.
     - name: Load Hanzo user configuration if present
       ansible.builtin.include_vars:
         file: "{{ ansible_facts.env.HOME }}/.config/hanzo/config.yml"
+        name: hanzo_user_config
       when: hanzo_config_stat.stat.exists
+      tags: [always]
+
+    # Allowlist: exactly these two keys cross into play scope, every
+    # other key in the file is ignored. Each is copied only when present,
+    # keeping `hanzo_fullname`/`hanzo_email` undefined otherwise so the
+    # home role's `is defined` gates still skip injection silently.
+    - name: Apply allowed user configuration key hanzo_fullname
+      ansible.builtin.set_fact:
+        hanzo_fullname: "{{ hanzo_user_config.hanzo_fullname }}"
+      when:
+        - hanzo_user_config is defined
+        - hanzo_user_config.hanzo_fullname is defined
+      become: false
+      tags: [always]
+
+    - name: Apply allowed user configuration key hanzo_email
+      ansible.builtin.set_fact:
+        hanzo_email: "{{ hanzo_user_config.hanzo_email }}"
+      when:
+        - hanzo_user_config is defined
+        - hanzo_user_config.hanzo_email is defined
+      become: false
       tags: [always]
 
   tasks:


### PR DESCRIPTION
## What changed

`playbook.yml` pre_tasks now load `~/.config/hanzo/config.yml` into its own namespace and copy exactly two keys into play scope:

- `ansible.builtin.include_vars` gains `name: hanzo_user_config` (stat gate and `always` tag unchanged).
- Two `set_fact` tasks (`become: false`, `tags: [always]`) copy `hanzo_user_config.hanzo_fullname` → `hanzo_fullname` and `hanzo_user_config.hanzo_email` → `hanzo_email`, each only when the key is present. Nothing else crosses over.
- README's Configuration section states that exactly `hanzo_fullname` and `hanzo_email` are read and any other key is ignored.

## Why

`~/.config/hanzo/config.yml` is user-writable, and `include_vars` without `name:` dumped **every** key in that file into play scope at a precedence that beats role vars. Anything with write access to the home directory could therefore plant `system_packages` (or any other role var) and have a `become: true` task install it as root. Namespacing the load plus an explicit allowlist removes that path while keeping today's contract: both keys are optional, and when one is absent it stays undefined so the home role's `when: hanzo_fullname is defined` gate skips identity injection silently instead of erroring.

## Verification

Lint:

```
pre-commit run --all-files
...
ansible-lint.............................................................Passed
Detect hardcoded secrets.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
codespell................................................................Passed
```

Container provisioning check (the config-present path — bootstrap writes both keys):

```
docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test-pr05 .
...
TASK [Load Hanzo user configuration if present] ********************************
ok: [localhost]
TASK [Apply allowed user configuration key hanzo_fullname] *********************
ok: [localhost]
TASK [Apply allowed user configuration key hanzo_email] ************************
ok: [localhost]
...
TASK [home : Set git user.name in identity sidecar] ****************************
changed: [localhost]
TASK [home : Set git user.email in identity sidecar] ***************************
changed: [localhost]
...
localhost                  : ok=49   changed=24   unreachable=0    failed=0    skipped=28   rescued=0    ignored=0
EXIT=0
```

Missing-config path, run inside that container (config removed first):

```
docker run --rm hanzo:test-pr05 bash -c 'rm -f ~/.config/hanzo/config.yml && cd ~/.local/src/hanzo && ansible-playbook playbook.yml --check'
...
TASK [Load Hanzo user configuration if present] ********************************
skipping: [localhost]
TASK [Apply allowed user configuration key hanzo_fullname] *********************
skipping: [localhost]
TASK [Apply allowed user configuration key hanzo_email] ************************
skipping: [localhost]
...
TASK [home : Set git user.name in identity sidecar] ****************************
skipping: [localhost]
TASK [home : Set git user.email in identity sidecar] ***************************
skipping: [localhost]
...
localhost                  : ok=44   changed=19   unreachable=0    failed=0    skipped=33   rescued=0    ignored=0
EXIT=0
```

Injection attempt, also inside the container — config carrying an extra `system_packages: ["hanzo-injected-package"]` alongside the two identity keys:

```
docker run --rm hanzo:test-pr05 bash -c '... > ~/.config/hanzo/config.yml && ansible-playbook playbook.yml --check --tags system -v'
TASK [Load Hanzo user configuration if present] ********************************
ok: [localhost] => {"ansible_facts": {"hanzo_user_config": {"hanzo_email": "...", "hanzo_fullname": "Test User", "system_packages": ["hanzo-injected-package"]}}, ...}
TASK [system : Install baseline development packages] **************************
changed: [localhost] => {..., "msg": "Would have installed 163 packages", "packages": ["adwaita-cursors", ...]}
```

The injected name appears only inside the `hanzo_user_config` dict; the package task still resolves `system_packages` from `roles/system/vars/main.yml`. No `ansible`/`hanzo`/`bootstrap.sh` invocation touched the host — every run above is inside the CachyOS container.

## Caveats

- `set_fact` precedence beats role vars, same as before, so the two identity keys still win where they are consumed — that is the intended contract, now limited to those two names.
- README's Development section still describes the container test as two staged runs; that text predates this PR and is left untouched.
