### PR TITLE
fix(bootstrap): validate identity input and escape YAML values

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ hanzo_fullname: "Your Name"
 hanzo_email: "your@email.com"
 ```
 
-Edit this file directly to update your settings. You can also set `HANZO_FULLNAME` and `HANZO_EMAIL` as environment variables for unattended provisioning (e.g., in containers) — the bootstrap script will write them to the config file in YAML form, escaping any embedded quotes or backslashes.
+Edit this file directly to update your settings. You can also set `HANZO_FULLNAME` and `HANZO_EMAIL` as environment variables for unattended provisioning (e.g., in containers) — the bootstrap script will write them to the config file in YAML form, escaping any embedded quotes or backslashes. Both variables are required: if either one is set but the other is empty, bootstrap stops instead of persisting a half-filled identity. When neither is set, bootstrap prompts and re-asks until both answers are non-empty.
 
 ## Architecture
 

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -58,14 +58,39 @@ if [ ! -d "$HANZO_DIR/.git" ]; then
     git clone "$HANZO_REPO" "$HANZO_DIR"
 fi
 
+trim_value() { printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+
+# YAML double-quoted scalar: backslashes first, then quotes.
+yaml_escape() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+
+# Under curl | bash stdin is the pipe — prompt and read via /dev/tty.
+prompt_required() {
+    local prompt="$1" value=""
+    while :; do
+        printf '%s' "$prompt" >/dev/tty
+        read -r value </dev/tty || fail "no input available — set HANZO_FULLNAME and HANZO_EMAIL instead"
+        value="$(trim_value "$value")"
+        if [ -n "$value" ]; then break; fi
+        printf 'A value is required.\n' >/dev/tty
+    done
+    printf '%s' "$value"
+}
+
 if [ ! -f "$CONFIG_FILE" ]; then
-    if [ -z "${HANZO_FULLNAME:-}" ]; then
-        # Under curl | bash stdin is the pipe — prompt via /dev/tty.
-        read -rp "Full name: " HANZO_FULLNAME </dev/tty
-        read -rp "Email: " HANZO_EMAIL </dev/tty
+    if [ -n "${HANZO_FULLNAME:-}" ] || [ -n "${HANZO_EMAIL:-}" ]; then
+        # Unattended: a half-filled identity would be persisted forever.
+        HANZO_FULLNAME="$(trim_value "${HANZO_FULLNAME:-}")"
+        HANZO_EMAIL="$(trim_value "${HANZO_EMAIL:-}")"
+        if [ -z "$HANZO_FULLNAME" ] || [ -z "$HANZO_EMAIL" ]; then
+            fail "HANZO_FULLNAME and HANZO_EMAIL must both be set to non-empty values"
+        fi
+    else
+        HANZO_FULLNAME="$(prompt_required "Full name: ")"
+        HANZO_EMAIL="$(prompt_required "Email: ")"
     fi
     mkdir -p "$(dirname "$CONFIG_FILE")"
-    printf 'hanzo_fullname: "%s"\nhanzo_email: "%s"\n' "$HANZO_FULLNAME" "$HANZO_EMAIL" > "$CONFIG_FILE"
+    printf 'hanzo_fullname: "%s"\nhanzo_email: "%s"\n' \
+        "$(yaml_escape "$HANZO_FULLNAME")" "$(yaml_escape "$HANZO_EMAIL")" > "$CONFIG_FILE"
     log "Configuration saved to $CONFIG_FILE"
 fi
 


### PR DESCRIPTION
## What changed

`bin/bootstrap.sh` identity block (the `[ ! -f "$CONFIG_FILE" ]` branch):

- **Interactive path** now loops per prompt until the *trimmed* answer is non-empty, reading (and printing the prompt) via `/dev/tty` so it still works under `curl | bash`.
- **Env path** now requires *both* `HANZO_FULLNAME` and `HANZO_EMAIL` to be non-empty after trimming whenever either is set; otherwise it fails with `HANZO_FULLNAME and HANZO_EMAIL must both be set to non-empty values`.
- **Escaping**: both values run through `sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'` (backslash first, then double quote) before being interpolated into the double-quoted YAML scalars.
- The config-exists short-circuit is unchanged; nothing is rewritten when `~/.config/hanzo/config.yml` already exists.

`README.md`: the configuration paragraph now also states that both env vars are required and that the prompts re-ask until non-empty (the escaping claim it already made is now actually true).

## Why

Pressing Enter at either prompt persisted `hanzo_fullname: ""` to `~/.config/hanzo/config.yml`, and because bootstrap short-circuits when the file exists, that empty identity was never asked for again — every later run provisioned git/user identity with blanks. The old `if [ -z "${HANZO_FULLNAME:-}" ]` gate also meant setting only `HANZO_FULLNAME` silently wrote an empty email. And the README promised quote/backslash escaping that the `printf` never performed: a name like `Emanuele "Ema" Palazzetti` produced invalid YAML, which fails every subsequent `hanzo` run.

## Verification

```
$ pre-commit run --all-files
... shellcheck...............................................................Passed
    ansible-lint.............................................................Passed
    (all 21 hooks Passed/Skipped)

$ docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test-pr03 .
#12 168.8 localhost                  : ok=47   changed=24   unreachable=0    failed=0    skipped=28   rescued=0    ignored=0
#13 naming to docker.io/library/hanzo:test-pr03 done

$ docker run --rm --entrypoint cat hanzo:test-pr03 /home/testuser/.config/hanzo/config.yml
hanzo_fullname: "Test User"
hanzo_email: "test@example.com"
```

Behavioral checks ran against a verbatim copy of the changed block in a harness (never `bootstrap.sh` itself, per CLAUDE.md — the container build is the only end-to-end run):

| case | result |
| --- | --- |
| `HANZO_FULLNAME='Emanuele "Ema" \Palazzetti\'`, `HANZO_EMAIL='  ai@ertx.dev  '` | writes `hanzo_fullname: "Emanuele \"Ema\" \\Palazzetti\\"`; `yaml.safe_load` round-trips to the exact input, email trimmed |
| only `HANZO_FULLNAME` set | exits 1 with the both-required message, no config written |
| `HANZO_EMAIL='   '` (whitespace) with a name set | exits 1, no config written |
| no env vars, driven over a real pty: empty line, whitespace line, `  Emanuele "Ema" \Palazzetti  `, `ai@ertx.dev` | re-prompts twice (`A value is required.`), trims, writes valid YAML that parses back to the intended values |
| config file already present | untouched, exits 0 |

## Caveats

- The `--ci` (full unattended) container build was not run; the required check for this PR is `--check`, and both exercise the same env-var identity path in `bootstrap.sh`.
- Escaping targets YAML double-quoted scalars only — a literal control character in an env var would still be written raw. Not reachable from the prompts, and out of scope here.
