### PR TITLE
refactor(tags): scope system role and encode languages-tools dependency

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -77,7 +77,7 @@
     - name: Run system role
       ansible.builtin.import_role:
         name: system
-      tags: [system, always]
+      tags: [system]
 
     - name: Run desktop role
       ansible.builtin.import_role:
@@ -94,10 +94,12 @@
         name: containers
       tags: [containers]
 
+    # Also tagged `tools`: the tools role's npm tasks `eval "$(fnm env)"`, so
+    # `--tags tools` on a fresh host must install fnm and Node first.
     - name: Run languages role
       ansible.builtin.import_role:
         name: languages
-      tags: [languages]
+      tags: [languages, tools]
 
     - name: Run tools role
       ansible.builtin.import_role:

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+# always: the languages (pyenv) and tools (gcloud) installers download into
+# this directory, so a selective run of either role still needs it created.
 - name: Ensure Hanzo cache directory exists
   ansible.builtin.file:
     path: "{{ ansible_facts.env.HOME }}/.cache/hanzo"
@@ -6,6 +8,7 @@
     mode: "0700"
   check_mode: false
   become: false
+  tags: [always]
 
 - name: Set system locale
   ansible.builtin.lineinfile:
@@ -14,10 +17,16 @@
     line: "LANG={{ system_locale }}"
   become: true
 
+# always: every other role's pacman installs rely on this sync db refresh.
+- name: Refresh pacman package databases
+  community.general.pacman:
+    update_cache: true
+  become: true
+  tags: [always]
+
 - name: Install baseline development packages
   community.general.pacman:
     name: "{{ system_packages }}"
-    update_cache: true
   become: true
 
 - name: Configure hibernation


### PR DESCRIPTION
## What changed

**`playbook.yml`**
- The `system` role import drops `always`: `tags: [system, always]` → `tags: [system]`.
- The `languages` role import gains `tools`: `tags: [languages]` → `tags: [languages, tools]`.

**`roles/system/tasks/main.yml`**
- `Ensure Hanzo cache directory exists` now carries `tags: [always]`.
- The pacman db refresh is split out of `Install baseline development packages` into a new `Refresh pacman package databases` task (`community.general.pacman` with only `update_cache: true`, `become: true`, `tags: [always]`), placed before the install task. The install task no longer sets `update_cache`.
- Each `always` tag is commented with the cross-role consumer that depends on it.

## Why

Tagging the whole `system` role `always` meant every selective run (`--tags home`, `--tags ai`, …) paid for locale config, the baseline package install, and the `limine-mkinitcpio` rebuild. Only two pieces of that role are genuinely cross-role state:

- the `~/.cache/hanzo` directory — `roles/languages/tasks/python.yml` (pyenv installer) and `roles/tools/tasks/cloud.yml` (gcloud installer) download into it;
- the pacman sync db refresh — every other role's `community.general.pacman` install assumes a fresh db.

Those two now carry `always` on their own, so the guarantee survives while the rest of the role becomes opt-in via `--tags system`.

The `languages`/`tools` pairing encodes a real dependency: `roles/tools/tasks/node_tools.yml` runs `eval "$(fnm env)"`, so `--tags tools` on a fresh host would fail without `languages` having installed fnm and Node.

## Verification

`pre-commit run --all-files` — all hooks pass (ansible-lint included):

```
shellcheck...............................................................Passed
ansible-lint.............................................................Passed
Detect hardcoded secrets.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
codespell................................................................Passed
```

`docker build --no-cache --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test-pr11 .` — succeeds, with the new task present and ordered before the install:

```
TASK [system : Ensure Hanzo cache directory exists] ****************************
TASK [system : Set system locale] **********************************************
TASK [system : Refresh pacman package databases] *******************************
TASK [system : Install baseline development packages] **************************
TASK [system : Configure hibernation] ******************************************
TASK [system : Regenerate initramfs and Limine boot entries] *******************
PLAY RECAP *********************************************************************
localhost                  : ok=48   changed=25   unreachable=0    failed=0    skipped=28   rescued=0    ignored=0
```

## Caveats

- The container check exercises the full (untagged) run only; selective `--tags` invocations are not covered by CI, so the new scoping is verified by inspection against the consumers listed above.
- `--tags system` on a fresh host still gets the db refresh and cache dir, since both are `always`; conversely a `--tags <anything>` run now performs a pacman db refresh, which is a cheap network sync but no longer free for tag-scoped runs that install nothing.