### PR TITLE
feat(system): assert encrypted backing device for hibernation swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CachyOS system provisioner powered by [Ansible](https://docs.ansible.com/). A si
 ## Requirements
 
 - [CachyOS](https://cachyos.org/) (Arch-based)
+- Full-disk encryption (LUKS) on the root filesystem to prevent unencrypted swap file
 - Internet connection for initial setup
 
 ## Quickstart

--- a/roles/system/tasks/hibernate.yml
+++ b/roles/system/tasks/hibernate.yml
@@ -1,4 +1,47 @@
 ---
+# Hibernation writes the entire contents of RAM — session keys, keyrings,
+# decrypted secrets — to /swap/swapfile, which lives on the root
+# filesystem. Refuse to configure it unless that filesystem is encrypted.
+# Both probes keep running under --check, so a dry run on an unencrypted
+# host fails here instead of reporting a clean plan.
+- name: Probe the device backing the root filesystem
+  ansible.builtin.command:
+    cmd: findmnt -no SOURCE /
+  register: system_root_source
+  changed_when: false
+  check_mode: false
+  become: true
+
+# findmnt reports a btrfs subvolume mount as `<device>[/subvol]`, so the
+# suffix is stripped before lsblk sees it. `-s` inverts the tree, listing
+# the mounted device and every layer underneath it — a LUKS install
+# always has a `crypt` layer among them, plain or stacked under LVM.
+- name: Probe the device stack under the root filesystem
+  ansible.builtin.command:
+    argv:
+      - lsblk
+      - -rsno
+      - TYPE
+      - >-
+        {{ system_root_source.stdout | regex_replace('\[.*\]$', '') }}
+  register: system_root_stack
+  changed_when: false
+  check_mode: false
+  become: true
+
+- name: Assert the root filesystem is on an encrypted device
+  ansible.builtin.assert:
+    that:
+      - "'crypt' in system_root_stack.stdout_lines"
+    fail_msg: >-
+      Hibernation writes the full contents of RAM to the swap file on the
+      root filesystem, so the root filesystem must sit on LUKS full-disk
+      encryption. No crypt layer was found under
+      {{ system_root_source.stdout | regex_replace('\[.*\]$', '') }}.
+      Reinstall CachyOS with full-disk encryption before provisioning
+      this machine.
+  become: true
+
 # CachyOS defaults to ZRam: zram-generator declares a RAM-sized zram0 swap
 # at priority 100 and cachyos-settings ships a udev rule that force-disables
 # Zswap on every zram0 change event. RAM-backed swap cannot hold a


### PR DESCRIPTION
## What changed

`roles/system/tasks/hibernate.yml` now opens with a hard gate, before any mutation:

1. `findmnt -no SOURCE /` — the device backing `/` (the `/swap` subvolume lives on the root btrfs).
2. `lsblk -rsno TYPE <dev>` — walks the stack under it; the `[/subvol]` suffix findmnt appends is stripped first.
3. `ansible.builtin.assert` — requires a `crypt` layer in that stack, with a `fail_msg` that explains hibernation writes RAM to disk and names the probed device.

Both probes carry `changed_when: false` and `check_mode: false`, so a `--check` run on an unencrypted host fails here too rather than printing a clean plan. All three tasks declare `become:` explicitly, and the registered vars use the `system_` role prefix.

README Requirements gains full-disk encryption (LUKS) as a stated requirement with the hibernation rationale.

## Why

suspend-then-hibernate writes the entire contents of RAM — session keys, keyrings, decrypted secrets — into the 128G swap file on the root filesystem. Nothing asserted that the disk underneath was encrypted, so an unencrypted install would have been provisioned into a configuration that dumps RAM to plaintext storage on every lid close. The decision was a hard assert plus a documented requirement, not a warning.

Stacked layouts still pass: `lsblk -s` lists every layer under the mount, so LVM-on-LUKS shows `crypt` alongside `lvm`.

## Verification

```
$ pre-commit run --all-files
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check that executables have shebangs.....................................Passed
check json...............................................................Passed
check for merge conflicts................................................Passed
check that scripts with shebangs are executable..........................Passed
check vcs permalinks.....................................................Passed
check yaml...............................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
shellcheck...............................................................Passed
ansible-lint.............................................................Passed
Detect hardcoded secrets.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
codespell................................................................Passed
```

```
$ docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test-pr09 .
...
localhost                  : ok=47   changed=24   unreachable=0    failed=0    skipped=28   rescued=0    ignored=0
#13 writing image sha256:3c1cc3884f45cb484eedfd92329d0a20ec9893585e106a80ba1c96af8465684c done
#13 naming to docker.io/library/hanzo:test-pr09 done
```

The container never reaches the new tasks — `hibernate.yml` is included under `when: host_has_systemd`, which is false without `/run/systemd/system`. Confirmed inside the built image:

```
$ docker run --rm hanzo:test-pr09 bash -lc 'cd ~/.local/src/hanzo && ansible-playbook playbook.yml --check --tags system'
TASK [system : Configure hibernation] ******************************************
skipping: [localhost]
...
localhost                  : ok=9    changed=2    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```

## Caveats

- The encrypted path itself (a `crypt` layer present → assert passes) cannot be exercised in CI: the container has no systemd, so the block is skipped entirely there. The logic was verified by construction and by the fail-closed shape — on any unencrypted root, including the container's overlay `/`, `lsblk` reports no `crypt` and the play stops.
- The assert refuses provisioning of the whole `system` role on an unencrypted host, by design. This is a behavior change for anyone running Hanzo on an unencrypted install.
