### PR TITLE
feat(system): provision UFW firewall

### DIFF
--- a/roles/system/tasks/firewall.yml
+++ b/roles/system/tasks/firewall.yml
@@ -1,0 +1,35 @@
+---
+# No allow rules on purpose: a laptop opens connections and accepts none, so
+# provisioning this host remotely needs an SSH rule added before the enable task.
+# Docker bypasses UFW — bind published ports to loopback if docker.service is enabled.
+- name: Provision UFW firewall
+  # community.general.ufw runs `ufw status verbose` before every operation, which
+  # fails in the unprivileged container and has no binary to call in check mode.
+  when:
+    - host_has_systemd
+    - not ansible_check_mode
+  block:
+    - name: Set default policy to deny incoming traffic
+      community.general.ufw:
+        direction: incoming
+        default: deny
+      become: true
+
+    - name: Set default policy to allow outgoing traffic
+      community.general.ufw:
+        direction: outgoing
+        default: allow
+      become: true
+
+    - name: Enable UFW
+      community.general.ufw:
+        state: enabled
+      become: true
+
+    # ufw.conf alone does not survive a reboot: ufw.service re-applies it at boot.
+    - name: Enable and start ufw service
+      ansible.builtin.systemd_service:
+        name: ufw.service
+        state: started
+        enabled: true
+      become: true

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -33,6 +33,9 @@
   ansible.builtin.include_tasks: hibernate.yml
   when: host_has_systemd
 
+- name: Configure firewall
+  ansible.builtin.include_tasks: firewall.yml
+
 # Runs on every invocation, last in the role, because a handler notification
 # is consumed once: lost or failed, it is never re-sent (issue #293).
 - name: Regenerate initramfs and Limine boot entries

--- a/roles/system/vars/main.yml
+++ b/roles/system/vars/main.yml
@@ -11,6 +11,7 @@ system_packages:
   - whois
   - tmux
   - shelly
+  - ufw
 
 system_locale: en_US.UTF-8
 


### PR DESCRIPTION
## What changed

- `roles/system/vars/main.yml`: adds `ufw` to `system_packages` (not in the CachyOS base image — `pacman -Qe` in `cachyos/cachyos:latest` lists 10 packages, none of them ufw; `pacman -S ufw` resolves to 0.36.2 from the repos).
- `roles/system/tasks/firewall.yml` (new): provisions the posture — default deny incoming, default allow outgoing, `state: enabled`, plus `ufw.service` enabled and started. Explicit `become: true` on every task.
- `roles/system/tasks/main.yml`: wires the new file in with `ansible.builtin.include_tasks` after the hibernation include and before the Limine rebuild (which must stay last in the role).

## Why

The virtualization role leaves the only persistent network-facing state on this machine: `Autostart: yes` on libvirt's `default` NAT network, which raises virbr0 and a dnsmasq on 192.168.122.0/24 whenever libvirtd is contacted. Nothing else in the repo declared who may reach the host. A firewall touched by hand — a temporary `ufw disable`, an `ufw allow` opened for one debugging session — drifts silently and is never repaired. Declaring the posture in the system role means every provisioning run restores it.

## Caveats

- **No allow rules are added.** This is a deliberate laptop posture: deny incoming, nothing opened. Provisioning this host *remotely* (SSH) would need an explicit `ufw allow` rule added to `firewall.yml` **before** the enable task, or the run drops the session carrying it.
- **Docker bypasses UFW.** dockerd programs its own DOCKER chain into iptables nat/filter ahead of `ufw-user-input`, so a container started with a published port (`-p 8080:80`) is reachable from the LAN despite the deny-incoming default. The containers role installs Docker but never enables `docker.service`, so nothing is published today; if it is ever enabled, bind published ports to loopback (`-p 127.0.0.1:8080:80`) instead of trusting this policy.
- **Gating.** All four tasks are gated on `host_has_systemd` and `not ansible_check_mode`, the same shape as the service tasks in `roles/hardware`. Verified reason, not caution: `community.general.ufw` shells out to `ufw status verbose` before *every* operation (including the `default` policy calls) and fails the task when that command does. Inside the unprivileged CachyOS test container it fails with `ERROR: problem running iptables ... Permission denied`, and in check mode the ufw package has not actually been installed, so the module cannot even find its binary. The block therefore skips cleanly in the container.
- **Not exercised on real hardware yet.** The container has no systemd, so the ufw tasks skip there by design; the enable path runs for the first time on the next real provisioning run. Worth watching then: `/etc/default/ufw` ships `DEFAULT_FORWARD_POLICY="DROP"`, and libvirt installs its own FORWARD rules for virbr0 — if guest networking regresses after enabling, that interaction is the first place to look.

## Verification

`pre-commit run --all-files` — all hooks pass (ansible-lint included):

```
shellcheck...............................................................Passed
ansible-lint.............................................................Passed
Detect hardcoded secrets.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
codespell................................................................Passed
```

`docker build --no-cache --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test-pr08c .` — succeeds, with the new tasks included and skipped cleanly:

```
TASK [system : Configure firewall] *********************************************
included: /home/testuser/.local/src/hanzo/roles/system/tasks/firewall.yml for localhost

TASK [system : Set default policy to deny incoming traffic] ********************
skipping: [localhost]

TASK [system : Set default policy to allow outgoing traffic] *******************
skipping: [localhost]

TASK [system : Enable UFW] *****************************************************
skipping: [localhost]

TASK [system : Enable and start ufw service] ***********************************
skipping: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=50   changed=24   unreachable=0    failed=0    skipped=31   rescued=0    ignored=0
```

The ufw package install itself was verified separately in a `cachyos/cachyos:latest` container (`pacman -S ufw` → ufw 0.36.2, ships `/usr/lib/systemd/system/ufw.service`, ships `ENABLED=no`), so the `--ci` path that actually installs it has a package to install.
