### PR TITLE
chore(git): ignore Claude spec drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ venv.bak/
 
 # Worktrees
 .worktrees/
+
+# Claude spec drafts
+.claude/specs/


### PR DESCRIPTION
Ignore `.claude/specs/` so Claude spec drafts stay out of version control.