### PR TITLE
feat(system): reduce hibernate delay to 1h

### DIFF
--- a/roles/system/defaults/main.yml
+++ b/roles/system/defaults/main.yml
@@ -19,6 +19,6 @@ system_locale: en_US.UTF-8
 system_swap_size: 128g
 
 # HibernateDelaySec for systemd-suspend-then-hibernate.service: time in
-# s2idle before transitioning to hibernate. 3h gives a long fast-resume
+# s2idle before transitioning to hibernate. 1h gives a fast-resume
 # window before paying the disk-write cost.
-system_hibernate_delay_sec: 10800
+system_hibernate_delay_sec: 3600


### PR DESCRIPTION
## Summary
- Lower `system_hibernate_delay_sec` from 10800 (3h) to 3600 (1h) so `systemd-suspend-then-hibernate.service` transitions from s2idle to hibernate after 1 hour.

## Testing
- `pre-commit run --all-files` passes.
- Container provisioning check passes: `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .` (`failed=0`).