### PR TITLE
fix(home): apply PowerDevil sleep mode to LowBattery profile

### DIFF
--- a/roles/home/tasks/kde.yml
+++ b/roles/home/tasks/kde.yml
@@ -35,8 +35,9 @@
   become: false
 
 # KDE Plasma 6: PowerDevil writes lid-action behavior here. SleepMode=3
-# = "Suspend then Hibernate" — set under both AC and Battery so behavior
-# is consistent regardless of power source.
+# = "Suspend then Hibernate" — set under all three power profiles (AC,
+# Battery, LowBattery) so behavior is consistent regardless of power
+# source.
 - name: Configure KDE PowerDevil sleep mode
   ansible.builtin.copy:
     dest: "{{ ansible_facts.env.HOME }}/.config/powerdevilrc"
@@ -46,6 +47,9 @@
       SleepMode=3
 
       [Battery][SuspendAndShutdown]
+      SleepMode=3
+
+      [LowBattery][SuspendAndShutdown]
       SleepMode=3
     mode: "0644"
   when: host_has_kde


### PR DESCRIPTION
### Related Issues

- None — bug found by inspection: sleep mode was configured for AC Power and Battery but not On Low Battery.

### Proposed Changes:

Plasma 6 PowerDevil has three power profiles: `AC`, `Battery`, and `LowBattery`. The deployed `~/.config/powerdevilrc` set `SleepMode=3` (Suspend then Hibernate) only under `[AC][SuspendAndShutdown]` and `[Battery][SuspendAndShutdown]`, so once the battery dropped into the low-battery profile the lid action fell back to plain suspend and the machine never hibernated. This adds the missing `[LowBattery][SuspendAndShutdown]` group with the same `SleepMode=3`, making the behavior consistent across all three power states.

### Testing:

- `pre-commit run --all-files` passes.
- Container provisioning check passes: `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .` (exit 0).

### Extra Notes (optional):

Group name verified against PowerDevil's Plasma 6 config schema (`LowBattery` is the third profile group, same `SuspendAndShutdown`/`SleepMode` keys).

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`