### PR TITLE
feat(kde): right-click by pressing anywhere with two fingers

### DIFF
--- a/.claude/skills/kde-config/lessons/input-devices.md
+++ b/.claude/skills/kde-config/lessons/input-devices.md
@@ -11,7 +11,14 @@ object at `/org/kde/KWin/InputDevice/<sysName>` is checked for a boolean
 a device name or vendor/product id.
 
 Settings (`naturalScroll`, `tapToClick`, ...) are plain writable D-Bus
-properties on `org.kde.KWin.InputDevice`, applied live. They persist to
+properties on `org.kde.KWin.InputDevice`, applied live.
+
+The "Right-click by" radio maps to two booleans, `clickMethodAreas`
+(bottom-right corner) and `clickMethodClickfinger` (anywhere with two
+fingers). libinput has a single click method, so writing either one flips
+both: `Device::setClickMethod()` in `kwin/src/backends/libinput/device.cpp`
+switches to the other method when a property is set to `false`. Writing
+`clickMethodClickfinger` alone is enough. They persist to
 `~/.config/kcminputrc` under a per-device group keyed by the device's
 hardware identity: `[Libinput][<vendorId decimal>][<productId decimal>][<device name>]`.
 

--- a/.claude/skills/kde-config/lessons/input-devices.md
+++ b/.claude/skills/kde-config/lessons/input-devices.md
@@ -11,14 +11,7 @@ object at `/org/kde/KWin/InputDevice/<sysName>` is checked for a boolean
 a device name or vendor/product id.
 
 Settings (`naturalScroll`, `tapToClick`, ...) are plain writable D-Bus
-properties on `org.kde.KWin.InputDevice`, applied live.
-
-The "Right-click by" radio maps to two booleans, `clickMethodAreas`
-(bottom-right corner) and `clickMethodClickfinger` (anywhere with two
-fingers). libinput has a single click method, so writing either one flips
-both: `Device::setClickMethod()` in `kwin/src/backends/libinput/device.cpp`
-switches to the other method when a property is set to `false`. Writing
-`clickMethodClickfinger` alone is enough. They persist to
+properties on `org.kde.KWin.InputDevice`, applied live. They persist to
 `~/.config/kcminputrc` under a per-device group keyed by the device's
 hardware identity: `[Libinput][<vendorId decimal>][<productId decimal>][<device name>]`.
 

--- a/roles/kde/defaults/main.yml
+++ b/roles/kde/defaults/main.yml
@@ -2,6 +2,8 @@
 # Touchpad. Booleans are quoted: busctl takes lowercase true|false.
 kde_touchpad_natural_scroll: "true"
 kde_touchpad_tap_to_click: "false"
+# Right-click method: clickfinger (two-finger press anywhere) or areas (bottom-right corner).
+kde_touchpad_click_method: clickfinger
 
 # Virtual desktops, and the Meta+N shortcuts bound to them.
 kde_virtual_desktops: 5

--- a/roles/kde/defaults/main.yml
+++ b/roles/kde/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 # Touchpad. Booleans are quoted: busctl takes lowercase true|false.
-# Click method: clickfinger (two-finger press anywhere) or areas (bottom-right corner).
 kde_touchpad_natural_scroll: "true"
 kde_touchpad_tap_to_click: "false"
 kde_touchpad_click_method: clickfinger

--- a/roles/kde/defaults/main.yml
+++ b/roles/kde/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # Touchpad. Booleans are quoted: busctl takes lowercase true|false.
+# Click method: clickfinger (two-finger press anywhere) or areas (bottom-right corner).
 kde_touchpad_natural_scroll: "true"
 kde_touchpad_tap_to_click: "false"
-# Right-click method: clickfinger (two-finger press anywhere) or areas (bottom-right corner).
 kde_touchpad_click_method: clickfinger
 
 # Virtual desktops, and the Meta+N shortcuts bound to them.

--- a/roles/kde/files/touchpad.sh
+++ b/roles/kde/files/touchpad.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Configures touchpad natural (inverted) scrolling and tap-to-click over
-# the KWin InputDevice D-Bus API. KWin applies live and persists to
+# Configures touchpad natural (inverted) scrolling, tap-to-click and the
+# right-click method over the KWin InputDevice D-Bus API. KWin applies live and persists to
 # ~/.config/kcminputrc. Prints one CHANGED line per property it had to
 # write; prints nothing when every touchpad already matches.
 #
 # Config:
 #   NATURAL_SCROLL=true|false   (default: true)  true = inverted scroll direction
 #   TAP_TO_CLICK=true|false     (default: false) false = tap-to-click disabled
+#   CLICK_METHOD=clickfinger|areas (default: clickfinger)
+#     clickfinger = right-click by pressing anywhere with two fingers
+#     areas       = right-click by pressing the bottom-right corner
 
 BUS_DEST="org.kde.KWin"
 MANAGER_PATH="/org/kde/KWin/InputDevice"
@@ -17,6 +20,13 @@ DEVICE_IFACE="org.kde.KWin.InputDevice"
 
 NATURAL_SCROLL="${NATURAL_SCROLL:-true}"
 TAP_TO_CLICK="${TAP_TO_CLICK:-false}"
+CLICK_METHOD="${CLICK_METHOD:-clickfinger}"
+
+case "$CLICK_METHOD" in
+  clickfinger) CLICKFINGER=true ;;
+  areas) CLICKFINGER=false ;;
+  *) echo "CLICK_METHOD must be clickfinger or areas, got: $CLICK_METHOD" >&2; exit 1 ;;
+esac
 
 get_prop() { # <device path> <property> -> lowercase value
   busctl --user --json=short get-property "$BUS_DEST" "$1" "$DEVICE_IFACE" "$2" \
@@ -44,6 +54,7 @@ while IFS= read -r sys_name; do
     found=1
     ensure_prop "$dev_path" naturalScroll "$NATURAL_SCROLL"
     ensure_prop "$dev_path" tapToClick "$TAP_TO_CLICK"
+    ensure_prop "$dev_path" clickMethodClickfinger "$CLICKFINGER"
   fi
 done <<< "$sys_names"
 

--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -15,12 +15,13 @@
 # D-Bus/scripting APIs) and are skipped in check mode by Ansible itself.
 # The whole role is gated on host_has_kde in playbook.yml.
 
-- name: Configure touchpad scrolling and tap-to-click
+- name: Configure touchpad scrolling, tap-to-click and right-click method
   ansible.builtin.script:
     cmd: touchpad.sh
   environment:
     NATURAL_SCROLL: "{{ kde_touchpad_natural_scroll }}"
     TAP_TO_CLICK: "{{ kde_touchpad_tap_to_click }}"
+    CLICK_METHOD: "{{ kde_touchpad_click_method }}"
   register: kde_touchpad_result
   changed_when: "'CHANGED' in kde_touchpad_result.stdout"
   become: false

--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -15,7 +15,7 @@
 # D-Bus/scripting APIs) and are skipped in check mode by Ansible itself.
 # The whole role is gated on host_has_kde in playbook.yml.
 
-- name: Configure touchpad scrolling, tap-to-click and right-click method
+- name: Configure touchpad settings
   ansible.builtin.script:
     cmd: touchpad.sh
   environment:


### PR DESCRIPTION
Sets Touchpad → Right-click by → *Pressing anywhere with two fingers*.

- `touchpad.sh` writes `clickMethodClickfinger` on every touchpad over `org.kde.KWin.InputDevice` (KWin flips `clickMethodAreas` off itself).
- New default `kde_touchpad_click_method: clickfinger` (`areas` restores bottom-right-corner).

Verification: lint and `--check` container pass; the kde role is skipped in CI, so please run `hanzo` twice on the laptop (first run should report CHANGED for `clickMethodClickfinger`, second no change) and confirm the System Settings radio shows the new selection.