### PR TITLE
feat(kde): size ghostty windows with a KWin window rule

### DIFF
--- a/.claude/skills/kde-config/SKILL.md
+++ b/.claude/skills/kde-config/SKILL.md
@@ -227,3 +227,4 @@ not from memory.
 | Darkly theme | `tasks/darkly.yml` | `lessons/theming.md` |
 | Copilot key (F23) binding | `tasks/main.yml` | — |
 | PowerDevil sleep mode | `tasks/main.yml` | — |
+| Window rules | `tasks/window-rules.yml` + `tasks/window-rule.yml` | `lessons/window-rules.md` |

--- a/.claude/skills/kde-config/lessons/window-rules.md
+++ b/.claude/skills/kde-config/lessons/window-rules.md
@@ -1,0 +1,90 @@
+# KWin window rules
+
+Facts behind the `Window rules` tasks in `roles/kde` — how `kwinrulesrc`
+is structured, which integers the rule keys take, and how KWin is told to
+reload. Confirmed against Plasma 6.7.4 and the `plasma/kwin` sources
+named below.
+
+## File layout
+
+`~/.config/kwinrulesrc` is one `[General]` group plus one group per rule:
+
+```ini
+[General]
+count=1
+rules=a75969c9-202a-41ab-a724-bec2bb07148a
+
+[a75969c9-202a-41ab-a724-bec2bb07148a]
+Description=Window settings for com.mitchellh.ghostty
+size=1600,1001
+sizerule=3
+types=1
+wmclass=ghostty com.mitchellh.ghostty
+wmclasscomplete=true
+wmclassmatch=1
+```
+
+- `rules` is the ordered list of rule group names
+  (`src/rulebooksettingsbase.kcfg`, key `rules`, type `StringList`,
+  comma-separated). `RuleBookSettings::usrRead()`
+  (`src/rulebooksettings.cpp`) loads exactly the groups it names.
+- **Group names are free-form.** The KCM mints UUIDs
+  (`RuleBookSettings::generateGroupName()`), but nothing checks the
+  shape — legacy files used `[1]`, `[2]`, … A descriptive, stable name
+  such as `hanzo-ghostty` is a legitimate group and survives KCM edits:
+  the KCM keeps existing group names and only generates new ones for
+  rules created in the UI.
+- `count` is labelled "legacy" in the kcfg: `usrRead()` consults it only
+  when `rules` is empty (it then synthesises `1..count`). The KCM still
+  rewrites it on every save, so keep it equal to the list length to
+  avoid a spurious "unsaved changes" state when the KCM next opens.
+- Rules are evaluated in list order; when several match, the first one
+  that sets a property wins for that property.
+
+## Enum integers (never symbolic names)
+
+All from `src/rules.h`:
+
+| Key | Enum | Values |
+|---|---|---|
+| `wmclassmatch`, `titlematch`, `windowrolematch`, … | `Rules::StringMatch` | 0 Unimportant, 1 Exact, 2 Substring, 3 RegExp |
+| `sizerule`, `positionrule`, … (`*rule` for set-type properties) | `Rules::SetRule` (anonymous base enum) | 0 Unused, 1 DontAffect, 2 Force, 3 Apply ("Apply initially"), 4 Remember, 5 ApplyNow, 6 ForceTemporarily |
+| `types` | `NET::WindowTypeMask` bitmask (`/usr/include/KF6/KWindowSystem/netwm_def.h`) | 1 Normal, default `AllTypesMask` (all bits) |
+| `wmclasscomplete` | Bool | `true` = match whole window class |
+
+`size` is a `QSize` serialised as `width,height`.
+
+## "Detect Window Properties" leaves inert keys behind
+
+The KCM's property detector copies the window's title into `title=` even
+when the user never enables title matching. Without a `titlematch`
+(default `UnimportantMatch`), `Rules::matchTitle()` (`src/rules.cpp`)
+returns true unconditionally, so the key is dead weight. When reproducing
+a GUI-made rule, carry only the keys whose `*match`/`*rule` companion is
+set — the snapshot above had `title=~ - fish` for exactly this reason.
+
+## Reload path
+
+System Settings' rules KCM does **not** call `reconfigure` after saving:
+`KCMKWinRules::save()` (`src/kcms/rules/kcmrules.cpp`) broadcasts the
+D-Bus signal `reloadConfig` on `/KWin` `org.kde.KWin`. KWin connects that
+signal to `Workspace::slotReloadConfig()`, which calls
+`Workspace::reconfigure()` — the same slot the `reconfigure` method
+reaches (`src/dbusinterface.cpp`). Both land in
+`Workspace::slotReconfigure()` (`src/workspace.cpp`), which does
+`m_rulebook->load()` and re-evaluates rules on every open window. So the
+role's existing `Reconfigure KWin` handler is sufficient; no rules-specific
+call exists.
+
+KWin does not watch `kwinrulesrc` for changes made by non-KConfig writers
+such as `ini_file`, so the handler is required, not a nicety.
+
+An `Apply` (3) rule only affects windows mapped after the reload — an
+already-open window keeps its size. Verify by opening a *new* window of
+the matched class.
+
+## Reading the list back
+
+`kreadconfig6 --file kwinrulesrc --group General --key rules` prints the
+raw comma-separated list, or an empty line with exit 0 when the file or
+key is absent — safe to use as the merge input on a fresh machine.

--- a/roles/kde/defaults/main.yml
+++ b/roles/kde/defaults/main.yml
@@ -39,3 +39,19 @@ kde_darkly_button_size: ButtonLarge
 
 # Panel layout, deployed here and applied from this path.
 kde_panel_layout_file: "{{ ansible_facts.env.HOME }}/.local/share/hanzo/panel-layout.js"
+
+# KWin window rules, keyed by the kwinrulesrc group that holds each one.
+# Properties are kwinrulesrc keys verbatim, so the ints are KWin's own
+# enums: *match is Rules::StringMatch (1 = exact), *rule is
+# Rules::SetRule (3 = apply initially), types is a NET::WindowTypeMask
+# bitmask (1 = normal window). Booleans are quoted: KConfig reads
+# lowercase true|false.
+kde_window_rules:
+  hanzo-ghostty:
+    Description: Window settings for com.mitchellh.ghostty
+    wmclass: ghostty com.mitchellh.ghostty
+    wmclasscomplete: "true"
+    wmclassmatch: 1
+    types: 1
+    size: 1600,1001
+    sizerule: 3

--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -143,6 +143,11 @@
   become: false
   notify: Reconfigure KWin
 
+# --- Window rules -----------------------------------------------------
+
+- name: Configure window rules
+  ansible.builtin.import_tasks: window-rules.yml
+
 # --- Panel layout -----------------------------------------------------
 # Deploying the layout is the change signal: the handler tears the panel
 # down and rebuilds it, so it must not run on an unchanged re-run.

--- a/roles/kde/tasks/window-rule.yml
+++ b/roles/kde/tasks/window-rule.yml
@@ -1,0 +1,17 @@
+---
+# One kwinrulesrc group per rule. kde_window_rule is the {key: group,
+# value: properties} item supplied by the including loop.
+
+- name: Write window rule {{ kde_window_rule.key }}
+  community.general.ini_file:
+    path: "{{ ansible_facts.env.HOME }}/.config/kwinrulesrc"
+    section: "{{ kde_window_rule.key }}"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    no_extra_spaces: true
+    mode: "0644"
+  loop: "{{ kde_window_rule.value | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  become: false
+  notify: Reconfigure KWin

--- a/roles/kde/tasks/window-rules.yml
+++ b/roles/kde/tasks/window-rules.yml
@@ -1,0 +1,41 @@
+---
+# KWin window rules. A rule is a kwinrulesrc group whose name appears in
+# the [General] rules list; KWin loads whatever names the list holds, so
+# Hanzo's rules carry stable names instead of the UUIDs the KCM mints.
+# The list is merged, never replaced, so rules added by hand survive.
+# count predates the list and is only read when the list is absent, but
+# the KCM still writes it, so it is kept in step.
+
+- name: Write window rule properties
+  ansible.builtin.include_tasks: window-rule.yml
+  loop: "{{ kde_window_rules | dict2items }}"
+  loop_control:
+    loop_var: kde_window_rule
+    label: "{{ kde_window_rule.key }}"
+
+- name: Read registered window rules
+  ansible.builtin.command:
+    cmd: kreadconfig6 --file kwinrulesrc --group General --key rules
+  register: kde_window_rules_registered
+  changed_when: false
+  check_mode: false
+  become: false
+
+- name: Register window rules
+  community.general.ini_file:
+    path: "{{ ansible_facts.env.HOME }}/.config/kwinrulesrc"
+    section: General
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    no_extra_spaces: true
+    mode: "0644"
+  vars:
+    kde_window_rules_existing: "{{ kde_window_rules_registered.stdout | split(',') | reject('eq', '') | list }}"
+    kde_window_rules_merged: "{{ kde_window_rules_existing + (kde_window_rules | list | reject('in', kde_window_rules_existing) | list) }}"
+  loop:
+    - option: rules
+      value: "{{ kde_window_rules_merged | join(',') }}"
+    - option: count
+      value: "{{ kde_window_rules_merged | length }}"
+  become: false
+  notify: Reconfigure KWin


### PR DESCRIPTION
### Related Issues

No related issue. This provisions a rule the maintainer used to create by hand.

### Proposed Changes:

Provisions the KWin window rule the maintainer used to create by hand in System Settings > Window Rules — window class exact match `ghostty com.mitchellh.ghostty`, whole class, Normal window type, Size 1600x1001 "Apply initially" — so every new ghostty window opens at that size.

Rules are treated as data: `kde_window_rules` in `roles/kde/defaults/main.yml`, keyed by the kwinrulesrc group name. Each rule's keys are written with `community.general.ini_file` (giving real change detection, visible under `--check`), then the group name is merged into the `[General] rules=` list rather than replacing it, so rules the maintainer adds by hand survive; `count` is kept equal to the list length because the KCM still rewrites that legacy key. The group name `hanzo-ghostty` is stable and descriptive instead of a UUID: KWin's `RuleBookSettings::usrRead()` (plasma/kwin `src/rulebooksettings.cpp`) loads whatever names the list holds, and the KCM only mints UUIDs for rules created in its UI.

Reload reuses the existing `Reconfigure KWin` handler. System Settings' rules KCM broadcasts the `reloadConfig` D-Bus signal (`src/kcms/rules/kcmrules.cpp`), which KWin routes to `Workspace::slotReloadConfig()` -> `reconfigure()`; the handler's `reconfigure` method call reaches the same `Workspace::slotReconfigure()` (`src/dbusinterface.cpp`, `src/workspace.cpp`), which does `m_rulebook->load()` and re-evaluates rules on open windows. KWin does not watch kwinrulesrc for writes by non-KConfig tools, so the handler is required.

Enum values were taken from source, not guessed: `wmclassmatch=1` is `Rules::ExactMatch`, `sizerule=3` is `Rules::Apply` ("apply only after initial mapping"), `types=1` is `NET::NormalMask` (`/usr/include/KF6/KWindowSystem/netwm_def.h`). All of this is recorded in the new lesson file `.claude/skills/kde-config/lessons/window-rules.md`, and the `kde-config` SKILL.md table gained a row.

The GUI-made rule on the maintainer's machine also carries `title=~ - fish` left behind by "Detect Window Properties"; without a `titlematch` it is inert (`Rules::matchTitle` in `src/rules.cpp`), so the provisioned rule deliberately omits it.

### Testing:

1. `pre-commit run --all-files` — every hook passed (ansible-lint, shellcheck, yaml, codespell, gitleaks, actionlint).
2. `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .` — exit 0; PLAY RECAP `localhost : ok=43 changed=25 unreachable=0 failed=0 skipped=57`. The kde role (and therefore the new tasks) is skipped in the container because it has no Plasma (`host_has_kde` is false), so CI proves syntax and lint only.
3. Container harness for the new tasks (scratch playbook with `include_role: kde, tasks_from: window-rules`, `kreadconfig6` and `busctl` stubbed on PATH, run inside the built image). This harness lives in the job's scratch directory, not in this PR. Six scenarios, all passed ("ALL SCENARIOS PASSED"):
   - S1 fresh HOME: writes the seven `[hanzo-ghostty]` keys plus `[General] rules=hanzo-ghostty` and `count=1`; `Reconfigure KWin` handler fires exactly once.
   - S2 rerun: `changed=0`, handler not fired.
   - S3 a hand-made UUID rule already present (copy of the maintainer's real kwinrulesrc): result `rules=a75969c9-202a-41ab-a724-bec2bb07148a,hanzo-ghostty`, `count=2`, the foreign group byte-for-byte untouched.
   - S4 rerun on S3: `changed=0`.
   - S5 registered rule with a hand-edited `size=800,600`: size restored to `1600,1001`, list and count unchanged.
   - S6 `--check` on a fresh HOME: no file written, tasks report the pending changes.
4. Live verification on a Plasma session is still owed and cannot run in CI: run `hanzo`, open a NEW ghostty window (an `Apply` rule affects only windows mapped after the reload; open windows keep their size), confirm 1600x1001, then run `hanzo` again and confirm the window-rule tasks report no change.

### Extra Notes (optional):

After the first `hanzo` run, the hand-made rule `a75969c9-202a-41ab-a724-bec2bb07148a` and `hanzo-ghostty` coexist (both match; the first one in the list wins per property, and they set the same size, so behavior is unaffected). Delete the hand-made one in System Settings > Window Rules to keep a single source of truth.

No warnings were emitted by any tool during this work.

### Checklist

- [ ] Related issue and proposed changes are filled — no related issue exists; proposed changes above stand in.
- [x] Tests are defining the correct and expected behavior — verified with the container harness described in Testing (item 3); the harness itself is not committed to this PR.
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`
</content>
