### PR TITLE
fix(cli): fail the run when the snapshot baseline cannot read snapper

### DIFF
--- a/bin/hanzo
+++ b/bin/hanzo
@@ -52,21 +52,36 @@ manual_steps() {
 # snapshots are never touched again, so later runs keep their history.
 # Deleting and creating through snapper (never raw btrfs) lets
 # limine-snapper-sync's plugin keep the boot menu in step.
+# Every snapper read lands in a plain assignment: a process substitution
+# or a pipeline into grep would drop snapper's exit status, and a failed
+# read must end the run rather than pass for an empty list.
 snapshot_baseline() {
     local description="Hanzo configuration"
-    local config configs numbers number
+    local config configs descriptions listed numbers number
     if ! command -v snapper >/dev/null 2>&1; then
         warn "Skipped snapshot baseline: snapper is not installed."
         return 0
     fi
-    mapfile -t configs < <(sudo snapper --csvout --no-headers list-configs --columns config)
+    listed="$(sudo snapper --csvout --no-headers list-configs --columns config)"
+    if [ -z "$listed" ]; then
+        warn "Skipped snapshot baseline: snapper has no configuration."
+        return 0
+    fi
+    mapfile -t configs <<<"$listed"
     for config in "${configs[@]}"; do
-        if sudo snapper --csvout --no-headers -c "$config" list --columns description | grep -Fxq "$description"; then
+        descriptions="$(sudo snapper --csvout --no-headers -c "$config" list --columns description)"
+        if grep -Fxq "$description" <<<"$descriptions"; then
             log "Snapshot baseline already exists in '$config' — leaving snapshots alone."
             continue
         fi
+        listed="$(sudo snapper --csvout --no-headers -c "$config" list --columns number)"
+        numbers=()
         # Number 0 is the live filesystem, not a snapshot.
-        mapfile -t numbers < <(sudo snapper --csvout --no-headers -c "$config" list --columns number | grep -vx 0 || true)
+        while IFS= read -r number; do
+            if [ -n "$number" ] && [ "$number" != 0 ]; then
+                numbers+=("$number")
+            fi
+        done <<<"$listed"
         if [ "${#numbers[@]}" -gt 0 ]; then
             log "Deleting ${#numbers[@]} snapshot(s) from '$config'..."
             sudo snapper -c "$config" delete --sync "${numbers[@]}"
@@ -136,6 +151,9 @@ ansible-playbook playbook.yml "${ARGS[@]}"
 # Last stage by design: the baseline must capture the AUR set, the
 # playbook, and its handlers. A dry run changes nothing worth keeping.
 if [ "$MODE" != "--check" ]; then
+    # The playbook outlasts sudo's cached credential: authenticate here,
+    # so any prompt lands before snapper rather than inside it.
+    sudo -v
     snapshot_baseline
 else
     warn "Skipped snapshot baseline: --check is a dry run."


### PR DESCRIPTION
### Related Issues

- No related issue: this fixes a defect found during an attended provisioning run on 24 Aug 2026.

### Proposed Changes:

`snapshot_baseline` in `bin/hanzo` read `snapper` through process substitutions and a pipeline into `grep`, both of which discard the command's exit status. On the 24 Aug 2026 run, the first `sudo snapper --csvout --no-headers list-configs --columns config` produced no output: `mapfile -t configs < <(...)` swallowed the failed exit status, the loop never ran, `snapshot_baseline` returned 0, and the handoff box printed while the snap-pac trail stayed in place (snapshots 39-88 that day). snapper's daemon log shows no client call reached snapperd at that time, so the command under `sudo` never got as far as D-Bus; the journal for that boot is not retained, so `sudo`'s own message is unrecoverable.

Two neighbouring reads had the same shape and worse consequences: a failing description read (`... | grep -Fxq`) made the `if` false and proceeded to delete every snapshot before creating the baseline; a failing number read (`... | grep -vx 0 || true`) created the baseline on top of the trail, which would have made the "already exists" branch permanent.

The fix:

- Every snapper read now lands in a plain assignment (`listed="$(sudo snapper ...)"`) so `set -e` ends the run on the real error, instead of the exit status being discarded by a process substitution or a pipeline into `grep`.
- An empty `list-configs` result is detected explicitly and returns after a warning, rather than passing through an empty loop silently.
- Snapshot 0 (the live filesystem, not a snapshot) is filtered in a bash `while read` loop instead of through `grep -vx 0 || true`, whose `|| true` masked the no-match exit status.
- `sudo -v` runs right before `snapshot_baseline`, after the playbook. The playbook run outlasts `sudo`'s cached credential, so any password prompt now lands visibly at that point rather than inside `snapshot_baseline`; a lapsed credential with nobody at the terminal now fails the run through `sudo`'s own password timeout instead of passing silently.

### Testing:

- `pre-commit run --all-files` passes (shellcheck, ansible-lint, all hooks).
- A throwaway stub harness (not committed) ran `snapshot_baseline` against fake `sudo`/`snapper` in eight scenarios: a failing `list-configs`, description read, number read, and delete each exit 1 with no further snapper call; an empty configuration list warns and returns 0; the happy path deletes `1 2 3` then creates; an existing baseline is left alone; a list holding only snapshot 0 creates without deleting.
- The local container dry run (`docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .`) did not run on this host: the docker daemon is inactive and starting it needs root. CI's `check` job runs the identical build on the PR.

### Extra Notes (optional):

For reviewers: `--check` never reaches the changed lines — the baseline and `sudo -v` are both skipped in a dry run. Only a `--ci` build reaches them, and there snapper is absent, so it takes the "snapper is not installed" skip branch.

### Checklist

- [x] Related issue and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior — no tests are committed: the repository has no test suite for `bin/hanzo`, and the stub run under Testing is a throwaway check, not part of the change.
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — not run on this host (docker daemon inactive, starting it needs root); CI's `check` job runs the equivalent build.
