### PR TITLE
feat(kde): start with an empty session on login

### DIFF
--- a/.claude/skills/kde-config/SKILL.md
+++ b/.claude/skills/kde-config/SKILL.md
@@ -228,3 +228,4 @@ not from memory.
 | Copilot key (F23) binding | `tasks/main.yml` | — |
 | PowerDevil sleep mode | `tasks/main.yml` | — |
 | Window rules | `tasks/window-rules.yml` + `tasks/window-rule.yml` | `lessons/window-rules.md` |
+| Session restore at login | `tasks/main.yml` (ini_file, no handler) | `lessons/session.md` |

--- a/.claude/skills/kde-config/lessons/session.md
+++ b/.claude/skills/kde-config/lessons/session.md
@@ -1,0 +1,68 @@
+# Desktop Session (ksmserver)
+
+Relevant to the session-restore task in `roles/kde/tasks/main.yml`
+(`kde_session_login_mode` in `defaults/main.yml`). Covers System Settings
+> Session > Desktop Session, whose KCM is `kcm_smserver` (shipped by
+`plasma-desktop`, source `plasma/plasma-desktop` `kcms/ksmserver/`), while
+the daemon it configures is `ksmserver` (`plasma/plasma-workspace`
+`ksmserver/`).
+
+## The whole KCM is one kcfg on `ksmserverrc [General]`
+
+`kcms/ksmserver/smserversettings.kcfg` (`kcfgfile name="ksmserverrc"`,
+group `General`) holds every control on that page:
+
+| GUI control | Key | Type | Values |
+|---|---|---|---|
+| Ask for confirmation | `confirmLogout` | Bool | `true` (default) / `false` |
+| (hidden) default leave option | `shutdownType` | Int | `0` default |
+| On login, launch apps that were open | `loginMode` | Enum | see below |
+| Ignored applications | `excludeApps` | String | comma/colon separated |
+
+The "Enter UEFI firmware settings" toggle is not a config key at all - the
+KCM's D-Bus code (`kcmsmserver.cpp`) talks to `org.freedesktop.login1`
+for that and nothing else.
+
+`loginMode` is a kcfg `Enum` with `<choices>` and no `value=` attributes,
+so KConfig writes the choice *name* (`kcoreconfigskeleton.cpp`
+`ItemEnum::writeConfig`). The radio buttons in `ui/main.qml` map by index:
+
+| Radio label | Index | Written value |
+|---|---|---|
+| On last logout | 0 | `restorePreviousLogout` (default, key absent) |
+| When session was manually saved | 1 | `restoreSavedSession` |
+| Start with an empty session | 2 | `emptySession` |
+
+A fresh machine has no `[General]` group in `~/.config/ksmserverrc` at
+all - the file only holds the `[Session: saved at previous logout]` /
+`[LegacySession: ...]` groups ksmserver rewrites at logout. `ini_file`
+adds `[General]` next to them and leaves those groups alone, as KConfig
+does in the other direction.
+
+## There is nothing to apply live - by design, not by omission
+
+`ksmserver/main.cpp` reads `loginMode` exactly once, in `main()`, right
+after the server object is built:
+
+- `restorePreviousLogout` -> `SESSION_PREVIOUS_LOGOUT`
+- `restoreSavedSession` -> `SESSION_BY_USER`
+- anything else (including `emptySession`) -> `startDefaultSession()`
+- a `ksmserver --restore` command-line flag overrides all of the above to
+  `SESSION_BY_USER`, and Plasma Mobile hard-codes `emptySession`.
+
+The actual restore is triggered later by `plasma-restoresession.service`
+calling `org.kde.ksmserver /KSMServer org.kde.KSMServerInterface.restoreSession`,
+which acts on the mode chosen at startup. `busctl --user introspect
+org.kde.ksmserver /KSMServer` exposes no reconfigure/reload method, and
+the KCM's `save()` is a bare `KQuickManagedConfigModule::save()` - it
+does not signal the daemon either. So the task is the plain
+config-key shape with **no handler**: the setting's entire meaning is
+"what happens at the next login", and that is exactly when it is read.
+
+## Verifying
+
+- Key landed: `kreadconfig6 --file ksmserverrc --group General --key loginMode`
+  prints `emptySession`; the KCM shows the matching radio selected.
+- Behavior: log out with windows open, log back in, nothing reopens. That
+  next login is the only real test - a `hanzo` re-run proving idempotency
+  says nothing about whether the value is honored.

--- a/roles/kde/defaults/main.yml
+++ b/roles/kde/defaults/main.yml
@@ -55,3 +55,7 @@ kde_window_rules:
     types: 1
     size: 1600,1001
     sizerule: 3
+
+# Session restore at login. One of restorePreviousLogout,
+# restoreSavedSession, emptySession — the ksmserver loginMode names.
+kde_session_login_mode: emptySession

--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -219,3 +219,17 @@
       SleepMode=3
     mode: "0644"
   become: false
+
+# --- Session restore --------------------------------------------------
+
+# ksmserver reads loginMode once, when the session starts, so the key
+# takes effect at the next login and there is no live apply to notify.
+- name: Configure session restore at login
+  community.general.ini_file:
+    path: "{{ ansible_facts.env.HOME }}/.config/ksmserverrc"
+    section: General
+    option: loginMode
+    value: "{{ kde_session_login_mode }}"
+    no_extra_spaces: true
+    mode: "0644"
+  become: false


### PR DESCRIPTION
### Related Issues

No related issue. This provisions a setting the maintainer used to set by hand in System Settings > Session > Desktop Session, like the previous KDE PRs in this repo.

### Proposed Changes:

Provisions the "Start with an empty session" option on that page: `roles/kde/tasks/main.yml` writes `loginMode=emptySession` under `[General]` in `~/.config/ksmserverrc` with `community.general.ini_file`, sourced from the new `kde_session_login_mode` default in `roles/kde/defaults/main.yml`.

The key, its value, and the missing handler were all taken from source, not guessed:

- `plasma-desktop` `kcms/ksmserver/smserversettings.kcfg`: `ksmserverrc` `[General]` `loginMode` is a kcfg `Enum` with choices `restorePreviousLogout` (default) / `restoreSavedSession` / `emptySession`. The same kcfg backs `confirmLogout`, `shutdownType`, and `excludeApps` — the rest of that System Settings page.
- `plasma-desktop` `kcms/ksmserver/ui/main.qml`: the "Start with an empty session" radio sets `loginMode` index 2, which is `emptySession`.
- `kconfig` `src/core/kcoreconfigskeleton.cpp` `ItemEnum::writeConfig`: enum entries are written by choice *name*, so the on-disk value is the literal string `emptySession`, matching what the GUI writes.
- `plasma-workspace` `ksmserver/main.cpp`: `loginMode` is read exactly once, in `main()` at session start — `restorePreviousLogout` maps to `SESSION_PREVIOUS_LOGOUT`, `restoreSavedSession` maps to `SESSION_BY_USER`, anything else (including `emptySession`) falls through to `startDefaultSession()`.
- `plasma-desktop` `kcms/ksmserver/kcmsmserver.cpp`: the KCM's `save()` is a bare `KQuickManagedConfigModule::save()` and makes no D-Bus call for this key (its only D-Bus code targets the UEFI firmware-setup toggle). `busctl --user introspect org.kde.ksmserver /KSMServer` exposes no reload/reconfigure method either. So the task deliberately notifies no handler: the setting's entire meaning is next-login behavior, and that is exactly when ksmserver reads it.

On the maintainer's machine, `~/.config/ksmserverrc` currently has no `[General]` group at all — only the `[Session: saved at previous logout]` / `[LegacySession: ...]` groups ksmserver rewrites at logout. `ini_file` adds `[General]` beside them and leaves those groups untouched.

All of this is recorded in the new lesson file `.claude/skills/kde-config/lessons/session.md`, and the `kde-config` `SKILL.md` table gained a row pointing at it.

### Testing:

1. `pre-commit run --all-files` passed every hook: ansible-lint, shellcheck, check yaml, codespell, Detect hardcoded secrets (gitleaks), Lint GitHub Actions workflow files (actionlint), and the generic pre-commit-hooks.
2. The container check `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .` was not run locally: `docker.service` is inactive on this host. CI runs it on the PR. The kde role is skipped in the container regardless (`host_has_kde` is false there), so that check proves syntax and lint only, not this task.
3. No scratch harness and no live run were executed for this change: `ansible` must never run on the host, and docker was down, so there was no container to run a harness in.
4. Live verification is still owed on the maintainer's Plasma machine and cannot run in CI: run `hanzo`; confirm `kreadconfig6 --file ksmserverrc --group General --key loginMode` prints `emptySession` and that System Settings > Session > Desktop Session shows "Start with an empty session" selected; run `hanzo` again and confirm the task reports no change; then log out with windows open and log back in — nothing should reopen. That next login is the only real test of the value being honored.

### Extra Notes (optional):

No warnings were emitted by any tool during this work.

### Checklist

- [x] Related issue and proposed changes are filled — no related issue exists; proposed changes above stand in.
- [ ] Tests are defining the correct and expected behavior — no automated test exists for this task; verification is the manual live-login check described above, which cannot run in CI.
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — not run locally because `docker.service` is inactive on this host; CI runs it on the PR, though the kde role (and this task) is skipped there since `host_has_kde` is false in the container.
