### PR TITLE
fix(hardware): drop the redundant /etc/asusd pre-create task

### DIFF
--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -21,16 +21,6 @@
     name: "{{ hardware_asus_pacman }}"
   become: true
 
-# asusctl ships without /etc/asusd, but asusd.service's namespace
-# directives reference it — the unit fails with status=226/NAMESPACE
-# on first start unless the directory exists.
-- name: Ensure /etc/asusd exists for asusd.service
-  ansible.builtin.file:
-    path: /etc/asusd
-    state: directory
-    mode: "0755"
-  become: true
-
 - name: Enable and start ASUS services
   ansible.builtin.systemd_service:
     name: "{{ item }}"


### PR DESCRIPTION
### Related Issues

N/A (the task came from PR #274).

### Proposed Changes:

Removes the `Ensure /etc/asusd exists for asusd.service` task, and its explanatory comment, from `roles/hardware/tasks/gz302.yml`. `Install ASUS packages` and `Enable and start ASUS services` remain, now adjacent.

The failure PR #274 fixed was real for asusctl 6.3.7-1: upstream commit a14e2e08 added `ProtectSystem=strict` + `ReadWritePaths=/etc/asusd/` to `asusd.service` without creating the directory, and fresh installs failed with `status=226/NAMESPACE`. It has since been fixed twice, independently:

- The CachyOS package ships the directory since 6.3.7-2 (CachyOS-PKGBUILDS b9ca05a549a8, `install -dm755 "${pkgdir}/etc/asusd"`; `pacman -Ql asusctl` lists `/etc/asusd/`), so the preceding `Install ASUS packages` task already creates it.
- Upstream 6.3.8 (commit 8ebbdfad, asus-linux/asusctl#781) added `ConfigurationDirectory=asusd`, which systemd 261 creates in `setup_exec_directory()` before `apply_mount_namespace()`, so the unit starts even where nothing else created the directory.

### Testing:

```
pre-commit run --all-files          # all hooks Passed
grep -rn /etc/asusd roles playbook.yml                # no matches
CI: lint + check (container --check provisioning) green
```

Actual outputs:

- `pre-commit run --all-files`: every hook reported Passed; `check for broken symlinks`, `check toml`, and `forbid new submodules` reported Skipped (no matching files). No hook failed.
- `grep -rn '/etc/asusd' roles playbook.yml`: no matches (exit status 1).
- CI `lint` and `check` jobs: green.

Audited host (asusctl 6.4.0, systemd 261): `asusd` active, `NRestarts=0`, zero NAMESPACE lines across five boots; the directory's creation time equals the package's install time. The Ansible task could only ever observe an existing directory.

### Extra Notes (optional):

No action is needed on already-provisioned hosts: the directory stays in place, owned by the package.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — run by the CI `check` job; no local docker daemon in the authoring environment.

