### PR TITLE
fix(hardware): drop the amdgpu sg_display override

### DIFF
--- a/roles/hardware/templates/amdgpu.conf.j2
+++ b/roles/hardware/templates/amdgpu.conf.j2
@@ -7,14 +7,6 @@
 # panel_power_savings, producing visible gamma/red-shift on this OLED panel.
 options amdgpu abmlevel={{ hardware_gz302_amdgpu_abmlevel }}
 
-# Disable scatter-gather display on this unified-memory APU. Per amdgpu
-# kernel docs: "Disable S/G display if you experience flickering or other
-# issues under memory pressure." Under pressure, pageable scanout pages
-# can be migrated/reclaimed faster than DC can refetch, producing torn
-# lines. The bug is APU+memory-pressure, not OLED-specific (OLED only
-# makes the artifact more visually obvious).
-options amdgpu sg_display={{ hardware_gz302_amdgpu_sg_display }}
-
 # Disable Compute Wavefront Save-Restore. Prevents GPU hangs and
 # graphical artifacts caused by register file synchronization issues
 # on RDNA 3.5.

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -16,8 +16,6 @@ hardware_gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x400"
 # Force ABM off: kernel auto-skip on OLED was reverted in 2024; PPD engages
 # ABM on battery and causes visible gamma/red-shift on AMD OLED panels.
 hardware_gz302_amdgpu_abmlevel: 0
-# Disable scatter-gather display to prevent flicker on unified-memory APUs under memory pressure.
-hardware_gz302_amdgpu_sg_display: 0
 # Disable Compute Wavefront Save-Restore to prevent GPU hangs on RDNA 3.5.
 hardware_gz302_amdgpu_cwsr_enable: 0
 


### PR DESCRIPTION
### Related Issues

N/A.

### Proposed Changes:

Removes the `sg_display=0` amdgpu modprobe override from the GZ302 hardware role:

- `roles/hardware/templates/amdgpu.conf.j2`: drops the `options amdgpu sg_display={{ hardware_gz302_amdgpu_sg_display }}` line and its explanatory comment block. The `abmlevel` and `cwsr_enable` blocks are untouched.
- `roles/hardware/vars/main.yml`: drops `hardware_gz302_amdgpu_sg_display` and its comment.

Why the override is no longer correct:

- At v7.2 `amdgpu_dm_init()` enables scatter/gather display for every APU from Carrizo onward (except RAVEN1 and DCN 2.0.3); there is no RAM-size threshold and no DCN 3.5 gate. The ">= 64 GB" rule the comment paraphrases existed for two releases: 08fffa74d977 disabled S/G on big-memory APUs (v6.5-rc6), ef064187a970 fixed the real cause — a page-table-base address truncation — in v6.6-rc2, and 169ed4ece837 reverted the disable in the same release because turning S/G off "can cause pin failures if enough VRAM isn't carved out by the BIOS".
- The flicker class this override masked on 7.0/7.1 kernels (PR #252) was a second bug: from v6.14 (4caacd1671b7) through v7.1 the async-flip mem_type guard compared a plane state with itself, so a scanned-out buffer moving between the VRAM carve-out and GTT was never rejected; 8e792f018e10 fixes it and is in v7.2. The comment's mechanism (pageable scanout pages reclaimed faster than DC can refetch) cannot occur: TTM never evicts, swaps or moves pinned buffers.
- Cost of keeping it: every scanout buffer must be pinned contiguously inside the 512 MiB VRAM carve-out, about 91 % occupied by an idle desktop on the audited host — forced evictions, stutter during buffer churn and "Failed to pin framebuffer" black frames when contiguous space runs out (the failure AMD cited when reverting the disable).

### Testing:

```
pre-commit run --all-files          # all hooks Passed
grep -rn sg_display roles playbook.yml                # no matches
CI: lint + check (container --check provisioning) green
```

Actual outputs:

- `pre-commit run --all-files` — every hook reported Passed (`check yaml`, `shellcheck`, `ansible-lint`, `codespell`, `Detect hardcoded secrets`, `Lint GitHub Actions workflow files`, and the generic hooks); `check for broken symlinks`, `check toml` and `forbid new submodules` reported Skipped with no matching files.
- `grep -rn sg_display roles playbook.yml` — exit 1, no matches.
- CI `lint` and `check` jobs: see the checks on this PR.

The audited host has run the kernel default (`sg_display=-1`, S/G active) since 2026-08-27.

### Extra Notes (optional):

- Soak plan: keep `journalctl -kf | grep -iE 'Failed to pin framebuffer|underflow|flip_done timed out'` open during heavy llama.cpp use and window churn for a week; if tearing ever appears, capture `amdgpu_gem_info` and report upstream instead of restoring the mask.
- Residual risk: a pre-7.2 fallback kernel (a 6.18 LTS) lacks 8e792f018e10 and would make the mask legitimate again.
- Hosts provisioned before this change: the template is rewritten on the next run and the system role rebuilds the initramfs; reboot to apply. Expected afterwards: `cat /sys/module/amdgpu/parameters/sg_display` = -1.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — not run locally (the docker daemon is not running in this environment and starting it needs root); covered by the CI `check` job on this PR.

