### PR TITLE
fix(hardware): drop the amdgpu cwsr_enable override

### DIFF
--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -17,13 +17,6 @@
     - host_has_systemd
   become: true
 
-- name: Deploy GPU modprobe config
-  ansible.builtin.template:
-    src: amdgpu.conf.j2
-    dest: /etc/modprobe.d/amdgpu.conf
-    mode: "0644"
-  become: true
-
 - name: Create XKB override directories
   ansible.builtin.file:
     path: "/etc/xkb/{{ item }}"

--- a/roles/hardware/templates/amdgpu.conf.j2
+++ b/roles/hardware/templates/amdgpu.conf.j2
@@ -1,2 +1,0 @@
-# AMD GPU configuration for Radeon 8060S (RDNA 3.5, Strix Halo)
-# Managed by Hanzo. Do not edit manually.

--- a/roles/hardware/templates/amdgpu.conf.j2
+++ b/roles/hardware/templates/amdgpu.conf.j2
@@ -1,7 +1,2 @@
 # AMD GPU configuration for Radeon 8060S (RDNA 3.5, Strix Halo)
 # Managed by Hanzo. Do not edit manually.
-
-# Disable Compute Wavefront Save-Restore. Prevents GPU hangs and
-# graphical artifacts caused by register file synchronization issues
-# on RDNA 3.5.
-options amdgpu cwsr_enable={{ hardware_gz302_amdgpu_cwsr_enable }}

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -5,6 +5,3 @@ hardware_asus_pacman:
 
 hardware_asus_services:
   - asusd
-
-# Disable Compute Wavefront Save-Restore to prevent GPU hangs on RDNA 3.5.
-hardware_gz302_amdgpu_cwsr_enable: 0


### PR DESCRIPTION
### Related Issues

- refs #254 (item "linux-firmware ships MES firmware >= 0x84 — review `amdgpu.cwsr_enable=0`")

This PR resolves that item with a different trigger than the issue expected: the fix was KFD/hsakmt save-area sizing, not MES firmware. Deliberately not "fixes #254", since the issue tracks more than this item.

### Proposed Changes:

Removes the `amdgpu.cwsr_enable=0` override from the `hardware` role:

- `roles/hardware/templates/amdgpu.conf.j2`: drops the `options amdgpu cwsr_enable={{ hardware_gz302_amdgpu_cwsr_enable }}` line and its comment block. With #344 and #349 merged that leaves only the header, so the second commit deletes the template and its `Deploy GPU modprobe config` task.
- `roles/hardware/vars/main.yml`: drops `hardware_gz302_amdgpu_cwsr_enable: 0` and its comment.

**Why the override is obsolete.** The line was copied from the th3cavalry GZ302 script (commit `fdd0190a43`), whose "register file synchronization issues" explanation cites nothing. AMD root-caused the gfx1151 hang class to an undersized CWSR save area for the 1.5x VGPR file. Both halves of the fix are live on the audited host: kernel `b42f3bf9536c` "bump minimum vgpr size for gfx1151" plus `71776e0965f9` exporting `cwsr_size` (v7.0), and the ROCr side consuming it (rocm-systems PR #2200, ROCm >= 7.2.1; host `hsa-rocr` 7.2.4, KFD topology `cwsr_size` 19185664, MES firmware 0x91). AMD's own commit `6b0d81297137` removed its MES workaround stating the hangs "were actually fixed by adjusting the VGPR size", and AMD staff on ROCm#5724 tell users to remove `cwsr_enable=0` once both halves are present.

**What the override costs.** KFD sizes and enforces the save area regardless of `cwsr_enabled`, so no memory is saved. What it removes is mid-wave preemption for every KFD queue (llama.cpp included): MES `REMOVE_QUEUE` must drain in-flight waves against a 2100 ms timeout, and KFD then forces a GPU reset. `rocgdb` wave state and CRIU return `-EINVAL`. 2026 gfx1151 hang reports occur with the flag set, or say it has no effect.

**Hosts provisioned before this change.** The deploy task is gone, so the playbook no longer rewrites `/etc/modprobe.d/amdgpu.conf`: remove it by hand, let the `system` role rebuild the initramfs on the next run (amdgpu loads from the initramfs on CachyOS), then reboot.

### Testing:

```
pre-commit run --all-files          # all hooks Passed
grep -rn cwsr roles playbook.yml                      # no matches
CI: lint + check (container --check provisioning) green
Merge gate (maintainer, on hardware): llama-bench before/after with the journal watch described in Extra Notes
```

Actual results:

- `pre-commit run --all-files`: every hook reported Passed; `check for broken symlinks`, `check toml`, and `forbid new submodules` Skipped (no matching files).
- `grep -rn 'cwsr' roles playbook.yml`: no matches.
- CI `lint` and `check` jobs: see the checks on this PR.

### Extra Notes (optional):

**MERGE GATE — do not merge before the `llama-bench` check.**

This is the only amdgpu override still applied on the audited host. Before merging, run the check:

1. Record `llama-bench` numbers with `cwsr_enable=0`.
2. Apply the removal, let the initramfs rebuild, reboot, and confirm `cat /sys/module/amdgpu/parameters/cwsr_enable` reports `1`.
3. Repeat the same script — single run, two concurrent clients, interrupted runs (`timeout -s INT`), and an s2idle entry during a run — with `journalctl -k -f | grep -iE 'amdgpu|kfd|MES'` open.

Pass criteria: no `MES failed|preemption failed|Failed to evict|page fault|GPU reset` lines, and tokens/s within noise. Then soak for a few weeks of normal use.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — not run locally (the docker daemon is not available in this environment); covered by the CI `check` job.


