### PR TITLE
feat(hardware)!: drop the Panel Replay mask from the kernel cmdline

### DIFF
--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -49,13 +49,6 @@
     mode: "0644"
   become: true
 
-- name: Ensure OLED kernel param in Limine cmdline
-  ansible.builtin.lineinfile:
-    path: /etc/default/limine
-    regexp: '^KERNEL_CMDLINE\[default\]\+=" amdgpu\.dcdebugmask='
-    line: 'KERNEL_CMDLINE[default]+=" {{ hardware_gz302_oled_kernel_param }}"'
-  become: true
-
 - name: Deploy suspend/resume hook
   ansible.builtin.template:
     src: gz302-suspend.sh.j2

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -9,10 +9,6 @@ hardware_asus_services:
 hardware_gz302_pacman:
   - keyd
 
-# Disable Panel Replay (DC_DISABLE_REPLAY=0x400) on the Strix Halo OLED panel
-# to prevent scrolling artifacts and flicker on DCN 3.5.
-hardware_gz302_oled_kernel_param: "amdgpu.dcdebugmask=0x400"
-
 # Force ABM off: kernel auto-skip on OLED was reverted in 2024; PPD engages
 # ABM on battery and causes visible gamma/red-shift on AMD OLED panels.
 hardware_gz302_amdgpu_abmlevel: 0


### PR DESCRIPTION
### Related Issues

- refs #254 — resolves the item "Linux 7.2 lands in linux-cachyos — review `amdgpu.dcdebugmask=0x400`". Not a `fixes`: the issue tracks further items.

### Proposed Changes:

Removes the Panel Replay mask from the GZ302 kernel cmdline:

- `roles/hardware/tasks/gz302.yml`: drops the task "Ensure OLED kernel param in Limine cmdline", which appended `KERNEL_CMDLINE[default]+=" amdgpu.dcdebugmask=0x400"` to `/etc/default/limine`.
- `roles/hardware/vars/main.yml`: drops `hardware_gz302_oled_kernel_param` and its rationale comment.

**What the bit does.** `amdgpu.dcdebugmask=0x400` is `DC_DISABLE_REPLAY`. At v7.2 it short-circuits exactly one thing: the Replay default for `IP_VERSION(3, 5, 1)` in `amdgpu_dm_initialize_drm_device()` (`amdgpu_dm.c`). It touches neither PSR nor suspend.

**Why it is inert on the GZ302EAC.** The panel never negotiates Replay in the first place. A root read of `/sys/kernel/debug/dri/1/eDP-1/replay_capability` on 2026-08-27 (linux-cachyos 7.2.0-1, linux-firmware 20260810) returned `Sink support: no`, `Driver support: yes`, `Config support: no`. In `replay_capability_show()`, "Sink support" is `amdgpu_dm_link_supports_replay()` — the panel's own DPCD gates (eDP >= 1.3, ALPM, adaptive-sync SDP, line-deviation fields) — while "Driver support" is the DMUB feature cap. So the DMUB firmware supports Replay and the panel fails a sink gate, and panel DPCD does not change with kernel, firmware or BIOS updates. Consistently, every 7.2 boot with `dcdebugmask=0` logs `eDP-1: PSR support ...`, a line the driver prints only when Replay setup returned false. The display runs PSR1 either way, which is why removing the mask changed nothing visible.

**The original premise was also wrong.** This unit ships an IPS LCD, not an OLED panel (EDID: Tianma `TL134ADXP03`, "Active Matrix LCD"). The variable name `hardware_gz302_oled_kernel_param` and the OLED flicker rationale carried over from #251 and #298 do not apply here.

### Testing:

```
pre-commit run --all-files                        # all hooks Passed (3 Skipped: no matching files)
grep -rn 'oled_kernel_param\|dcdebugmask' roles playbook.yml       # no matches (exit 1); repo-wide grep also clean
CI: lint + check (container --check provisioning) green
```

### Extra Notes (optional):

**Hosts provisioned before this change** keep a stale entry and need one manual step: remove the line `KERNEL_CMDLINE[default]+=" amdgpu.dcdebugmask=0x400"` from `/etc/default/limine`, let the `system` role's `limine-mkinitcpio` task regenerate the boot entries on the next run (or run it by hand), then reboot. That manual step is why the commit is marked as a breaking change. Already done on the audited host — `/sys/module/amdgpu/parameters/dcdebugmask` reads `0`.

**Sentinel after each kernel upgrade** (no root needed):

```
journalctl -b -k | grep 'eDP-1: PSR support'
```

Present means Replay is still not negotiated and this removal remains correct. Absent means the sink gates changed upstream: read `replay_capability` again and reconsider re-adding the mask.

### Checklist

- [x] Related issue and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior — the repository has no unit-test suite; behavior is covered by the container provisioning check in CI, and by the on-host `replay_capability` and journal readings quoted above.
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — run by the CI `check` job on this PR.

