### PR TITLE
feat(hardware)!: drop the MT7925 Wi-Fi power-save override

### DIFF
--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -1,14 +1,4 @@
 ---
-- name: Restart network stack
-  ansible.builtin.shell: |
-    set -euo pipefail
-    systemctl restart NetworkManager
-    nmcli radio wifi off
-    nmcli radio wifi on
-    sleep 5
-  changed_when: true
-  become: true
-
 - name: Restart keyd
   ansible.builtin.systemd_service:
     name: keyd

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -1,21 +1,6 @@
 ---
 # ASUS ROG Flow Z13 (GZ302) hardware fixes.
 
-# Wifi-powersave fix runs first and is flushed immediately so the
-# MT7925 stops dropping long-running TCP transfers before any role
-# downloads anything (curl-based installers in later roles, pacman in
-# this one).
-- name: Deploy NetworkManager wifi powersave drop-in
-  ansible.builtin.template:
-    src: wifi-powersave.conf.j2
-    dest: /etc/NetworkManager/conf.d/wifi-powersave.conf
-    mode: "0644"
-  become: true
-  notify: Restart network stack
-
-- name: Apply wifi powersave before continuing
-  ansible.builtin.meta: flush_handlers
-
 - name: Install ASUS packages
   community.general.pacman:
     name: "{{ hardware_asus_pacman }}"

--- a/roles/hardware/templates/wifi-powersave.conf.j2
+++ b/roles/hardware/templates/wifi-powersave.conf.j2
@@ -1,7 +1,0 @@
-# MediaTek MT7925 NetworkManager powersave override
-# Managed by Hanzo. Do not edit manually.
-#
-# NM defaults to wifi.powersave=3 (enabled). On MT7925 this causes
-# disconnects, throttled upload, and slow throughput. Set to 2 (disabled).
-[connection]
-wifi.powersave = {{ hardware_gz302_wifi_powersave }}

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -19,14 +19,3 @@ hardware_gz302_amdgpu_cwsr_enable: 0
 hardware_gz302_asus_usb_vendor: "0b05"
 hardware_gz302_asus_keyboard_product: "1a30"
 hardware_gz302_asus_lightbar_product: "18c6"
-
-# NetworkManager wifi.powersave for MT7925. NM's default (3 = enabled)
-# causes disconnects and throttled throughput on this chip; 2 = disabled is
-# the cross-distro workaround (Arch, Fedora, Framework, Z13 communities).
-# Trade-off: ~1-2% extra system idle power; does NOT affect suspend (the
-# mt7925_pci_suspend driver callback is a separate code path from runtime
-# nl80211 PS). 1 = ignore is not a substitute because the mt76 driver
-# default is PS-on (the 2023 patch to flip it was rejected upstream).
-# Flip back to 3 if a future kernel/firmware combo fixes the regression.
-# Values: 0 = use default, 1 = ignore, 2 = disable, 3 = enable.
-hardware_gz302_wifi_powersave: 2


### PR DESCRIPTION
### Related Issues

- refs #254 (item "MT7925 Wi-Fi stability after PR #253 — add ASPM disable if PS-off alone is insufficient")

That item is moot rather than fixed: the ASPM commit it anticipates (b0dddf55af81, v7.2) is MT7927-only and states that MT7925 handles L1 gracefully.

### Proposed Changes:

Removes the global NetworkManager `wifi.powersave=2` drop-in the `hardware` role deployed on the GZ302, together with everything that existed only to serve it: the `wifi-powersave.conf.j2` template, the `hardware_gz302_wifi_powersave` variable, the `flush_handlers` barrier that forced the setting to apply before any later role downloaded anything, and the `Restart network stack` handler.

What the drop-in actually did: with `wifi.powersave=2` NetworkManager sets the interface's 802.11 power save off, which prevents mac80211 from ever asking the MT7925 firmware for dynamic power save (`vif.cfg.ps` -> `BSS_CHANGED_PS` -> `mt7925_mcu_uni_bss_ps`). Driver runtime PM, deep sleep, PCIe ASPM and system suspend are separate paths and were never affected. Nothing in v7.2 or the 2026 MT7925 firmware changed the default, so the drop-in was still doing something — the question was whether its reasons hold.

They do not, in three places:

- NetworkManager 1.58 does not "default to 3". Its default is `ignore`; power save is on because the kernel is built with `CONFIG_CFG80211_DEFAULT_PS=y`.
- The "~200 Mbps upload vs 1.2 Gbps" figure is the MT7927 PCIe-ASPM symptom, not an MT7925 power-save symptom.
- The "1-2 % idle power" number was unsourced.

The provisioning stall that PR #273 attributed to power save was never demonstrated.

Removal leaves the kernel default (dynamic power save on).

### Testing:

    pre-commit run --all-files                                        # all hooks Passed
    grep -rn 'powersave\|Restart network stack\|flush_handlers' roles playbook.yml      # no matches
    CI: lint + check (container --check provisioning) green

Actual outputs:

- `pre-commit run --all-files`: every hook Passed; `check for broken symlinks`, `check toml` and `forbid new submodules` Skipped (no matching files). ansible-lint Passed.
- `grep -rn 'powersave\|Restart network stack\|flush_handlers' roles playbook.yml`: exit 1, no matches.
- CI: see the checks on this PR.

A/B measurement on the GZ302EAC, 2026-08-27 (linux-cachyos 7.2.0-1, MT7925 firmware WM 20260605, same AP at -66 dBm), two rounds, four runs of 60 s quiet + 120 s `ping -i 0.2` + 180 s download each: 2400/2400 pings answered, no disconnects, no mt7925 errors in either state. Round 2 on battery: idle draw 8.61 W with power save off vs 8.23 W with it on (-0.38 W, single pair, direction and magnitude as 802.11 doze predicts); RTT avg 10.6 vs 11.1 ms (the round-1 latency gap did not reproduce); downloads 127 vs 114 Mbit/s, internet-bound and within the mirror's own variance; retries +4826 vs +3690, failed 0/0.

### Extra Notes (optional):

Breaking for hosts provisioned before this change: the drop-in file is not removed by re-running the playbook. Clean it up by hand with

    sudo rm /etc/NetworkManager/conf.d/wifi-powersave.conf && sudo systemctl restart NetworkManager

after which `iw dev wlan0 get power_save` should read `on`.

If a future MT7925 firmware brings disconnects back, the first thing to try is the per-profile override `nmcli con modify <profile> 802-11-wireless.powersave 2`, proven with the same A/B, not a global drop-in.

Reviewer focus: the `flush_handlers` barrier in `roles/hardware/tasks/gz302.yml` existed only to apply the drop-in before later roles ran their curl-based installers; with the drop-in gone it has no remaining purpose, and `Restart network stack` in `roles/hardware/handlers/main.yml` had no other notifier.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — not run locally (the Docker daemon is not running in this environment and starting it needs root); covered by the `check` job on this PR.

