### PR TITLE
fix(hardware): drop the amdgpu abmlevel override

### DIFF
--- a/roles/hardware/templates/amdgpu.conf.j2
+++ b/roles/hardware/templates/amdgpu.conf.j2
@@ -1,12 +1,6 @@
 # AMD GPU configuration for Radeon 8060S (RDNA 3.5, Strix Halo)
 # Managed by Hanzo. Do not edit manually.
 
-# Force ABM off. The kernel patch that auto-skipped ABM on OLED panels
-# (76cb763e6ea6) was reverted in 2024 — ABM is still active on OLED in 7.0
-# mainline, and power-profiles-daemon ≥0.20 engages it on battery via
-# panel_power_savings, producing visible gamma/red-shift on this OLED panel.
-options amdgpu abmlevel={{ hardware_gz302_amdgpu_abmlevel }}
-
 # Disable Compute Wavefront Save-Restore. Prevents GPU hangs and
 # graphical artifacts caused by register file synchronization issues
 # on RDNA 3.5.

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -9,9 +9,6 @@ hardware_asus_services:
 hardware_gz302_pacman:
   - keyd
 
-# Force ABM off: kernel auto-skip on OLED was reverted in 2024; PPD engages
-# ABM on battery and causes visible gamma/red-shift on AMD OLED panels.
-hardware_gz302_amdgpu_abmlevel: 0
 # Disable Compute Wavefront Save-Restore to prevent GPU hangs on RDNA 3.5.
 hardware_gz302_amdgpu_cwsr_enable: 0
 


### PR DESCRIPTION
### Related Issues

N/A.

### Proposed Changes:

`roles/hardware` pinned `options amdgpu abmlevel=0` on the GZ302, justified in the
template comment by two claims about the panel and the kernel. Both are false, so
the override is removed along with the `hardware_gz302_amdgpu_abmlevel` variable
that fed it.

- Both premises of the override are false. The panel is an IPS LCD (EDID:
  Tianma `TL134ADXP03`, "Active Matrix LCD"; PWM backlight path), so the
  "gamma/red-shift on AMD OLED" story does not apply. And commit
  76cb763e6ea6 ("Don't register panel_power_savings on OLED panels") was
  never reverted: it landed in v6.11, is an ancestor of v7.2 and survives as
  `amdgpu_dm_should_create_sysfs()`. The 2024 revert the comment refers to
  (95aaa207e9ef) undoes an unrelated change.
- Nothing engages ABM behind the user's back on this stack: at v7.2 eDP
  connectors reset to `ABM_LEVEL_IMMEDIATE_DISABLE`; the "adaptive backlight
  modulation" DRM property is attached only when `abmlevel=-1` and KWin 6.7.4
  commits it at 0 on every modeset (`kscreen-doctor -o`: "supported, set to
  0"), which makes `panel_power_savings` writes return -EBUSY;
  power-profiles-daemon 0.30 ships `amdgpu_panel_power` as opt-in and it is
  disabled on the audited host.
- What `abmlevel=0` actually did: remove the sysfs file and the DRM property,
  so KDE reports ABM unsupported — the control point is lost and nothing is
  gained. The audited host has run the kernel default (`abmlevel=-1`) since
  2026-08-27 with no visible change; ABM can only turn on if the user raises
  KDE's "Adaptive backlight modulation" slider.

Diff scope: two files, 9 deleted lines, 0 added.

- `roles/hardware/templates/amdgpu.conf.j2`: removed the four-line ABM comment
  block and `options amdgpu abmlevel={{ hardware_gz302_amdgpu_abmlevel }}`.
- `roles/hardware/vars/main.yml`: removed the two-line ABM comment and
  `hardware_gz302_amdgpu_abmlevel: 0`.

The `sg_display` and `cwsr_enable` options in the same template are untouched.

### Testing:

```
pre-commit run --all-files          # all hooks Passed
grep -rn abmlevel roles playbook.yml                  # no matches
CI: lint + check (container --check provisioning) green
```

Actual outputs from this run:

```
$ pre-commit run --all-files
21 hooks ran: 18 Passed, 3 Skipped for having no matching files (check for
broken symlinks, check toml, forbid new submodules). ansible-lint Passed.

$ grep -rn abmlevel roles playbook.yml
(no output, exit 1 — no matches)
```

The container `--check` provisioning run is covered by the `check` CI job on this
PR; the Docker daemon is not available in the environment this branch was
prepared in.

### Extra Notes (optional):

- This corrects the narrative of PR #252, which introduced the override on
  the OLED premise.
- Hosts provisioned before this change: the template is rewritten on the next
  run and the system role rebuilds the initramfs; reboot to apply. Expected
  afterwards: `cat /sys/module/amdgpu/parameters/abmlevel` = -1.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior — this repository has
  no unit-test suite; the behavioral gate is the container `--check` provisioning
  run in CI, which renders the amended template.
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — run by the `check` CI job on this PR.

