### PR TITLE
feat(hardware)!: replace keyd with an XKB override for the Copilot key

### DIFF
--- a/roles/hardware/files/xkb/rules/evdev
+++ b/roles/hardware/files/xkb/rules/evdev
@@ -1,0 +1,4 @@
+// Managed by Hanzo. Do not edit manually.
+! include %S/evdev
+! model = symbols
+  * = +gz302(copilot)

--- a/roles/hardware/files/xkb/symbols/gz302
+++ b/roles/hardware/files/xkb/symbols/gz302
@@ -1,0 +1,8 @@
+// Managed by Hanzo. Do not edit manually.
+// xkeyboard-config >= 2.44 maps Shift+Super+F23 (the Copilot chord) to
+// XF86Assistant, which Qt has no key for, so Plasma cannot bind it.
+// Deliver plain F23 at every level instead.
+partial alphanumeric_keys
+xkb_symbols "copilot" {
+    key <FK23> { type[Group1] = "ONE_LEVEL", [ F23 ] };
+};

--- a/roles/hardware/handlers/main.yml
+++ b/roles/hardware/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: Restart keyd
-  ansible.builtin.systemd_service:
-    name: keyd
-    state: restarted
-  become: true

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -31,12 +31,6 @@
     mode: "0755"
   become: true
 
-# xkeyboard-config >= 2.44 types <FK23> as PC_SHIFT_SUPER_LEVEL2, so the
-# Copilot chord (LeftShift+LeftMeta+F23) reaches Plasma as XF86Assistant,
-# a keysym Qt has no key for and kglobalaccel cannot bind. /etc/xkb is on
-# libxkbcommon's include path: the override delivers F23 at every level
-# and the kde role binds the chord as Meta+Shift+F23. KWin reads the
-# include path once at startup, so the first deploy needs a new session.
 - name: Create XKB override directories
   ansible.builtin.file:
     path: "/etc/xkb/{{ item }}"

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -31,25 +31,32 @@
     mode: "0755"
   become: true
 
-- name: Install GZ302 packages
-  community.general.pacman:
-    name: "{{ hardware_gz302_pacman }}"
+# xkeyboard-config >= 2.44 types <FK23> as PC_SHIFT_SUPER_LEVEL2, so the
+# Copilot chord (LeftShift+LeftMeta+F23) reaches Plasma as XF86Assistant,
+# a keysym Qt has no key for and kglobalaccel cannot bind. /etc/xkb is on
+# libxkbcommon's include path: the override delivers F23 at every level
+# and the kde role binds the chord as Meta+Shift+F23. KWin reads the
+# include path once at startup, so the first deploy needs a new session.
+- name: Create XKB override directories
+  ansible.builtin.file:
+    path: "/etc/xkb/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - rules
+    - symbols
   become: true
 
-- name: Deploy keyd config
-  ansible.builtin.template:
-    src: keyd-default.conf.j2
-    dest: /etc/keyd/default.conf
+- name: Deploy XKB rules override
+  ansible.builtin.copy:
+    src: xkb/rules/evdev
+    dest: /etc/xkb/rules/evdev
     mode: "0644"
   become: true
-  notify: Restart keyd
 
-- name: Enable and start keyd
-  ansible.builtin.systemd_service:
-    name: keyd
-    state: started
-    enabled: true
-  when:
-    - not ansible_check_mode
-    - host_has_systemd
+- name: Deploy Copilot key XKB symbols
+  ansible.builtin.copy:
+    src: xkb/symbols/gz302
+    dest: /etc/xkb/symbols/gz302
+    mode: "0644"
   become: true

--- a/roles/hardware/templates/keyd-default.conf.j2
+++ b/roles/hardware/templates/keyd-default.conf.j2
@@ -1,9 +1,0 @@
-# Managed by Hanzo. Do not edit manually.
-[ids]
-*
-
-[main]
-# ASUS Copilot key (Microsoft spec: LeftShift+LeftMeta+F23) -> bare F23.
-# Without stripping the modifiers, KDE only receives LeftShift+LeftMeta
-# (the F23 keysym never reaches userspace as part of the chord).
-leftshift+leftmeta+f23 = f23

--- a/roles/hardware/vars/main.yml
+++ b/roles/hardware/vars/main.yml
@@ -6,9 +6,6 @@ hardware_asus_pacman:
 hardware_asus_services:
   - asusd
 
-hardware_gz302_pacman:
-  - keyd
-
 # Disable Compute Wavefront Save-Restore to prevent GPU hangs on RDNA 3.5.
 hardware_gz302_amdgpu_cwsr_enable: 0
 

--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -188,13 +188,16 @@
 # `[services][<file>.desktop]` group; top-level `[<file>.desktop]` groups
 # are ignored and deleted on daemon start. ini_file has no nested-group
 # syntax, hence the `]`+`[` embedded in `section`. The launcher itself is
-# desktop-agnostic and deployed by the home role.
-- name: Bind Copilot key (F23) to Claude Code launcher
+# desktop-agnostic and deployed by the home role. The hardware role's XKB
+# override delivers the Copilot chord as F23 with Shift and Meta still
+# held (a ONE_LEVEL key consumes no modifier), so kglobalaccel sees
+# Meta+Shift+F23.
+- name: Bind Copilot key chord to Claude Code launcher
   community.general.ini_file:
     path: "{{ ansible_facts.env.HOME }}/.config/kglobalshortcutsrc"
     section: "services][{{ claude_launcher_file }}"
     option: _launch
-    value: "F23"
+    value: "Meta+Shift+F23"
     no_extra_spaces: true
     mode: "0644"
   become: false


### PR DESCRIPTION
### Related Issues

N/A — no tracking issue.

### Proposed Changes:

**Problem.** The kernel delivers the GZ302's Copilot key as
`LeftShift+LeftMeta+KEY_F23` (hid-input boot-keyboard mapping; the old keyd
comment claiming "the F23 keysym never reaches userspace" was wrong).
xkeyboard-config >= 2.44 types `<FK23>` as `PC_SHIFT_SUPER_LEVEL2`
(`symbols/inet`), turning the chord into `XF86Assistant`; Qt 6 has no
`Qt::Key` for it, so kglobalaccel sees key 0 ("Invalid key code", KDE bug
502639) and Plasma cannot bind the raw chord.

keyd worked around that from the wrong layer: its exclusive evdev grab
re-injects everything through a uinput device with no vendor/product id, and
libinput 1.31 only enables disable-while-typing for an external-tagged
touchpad (the GZ302's is) when keyboard and touchpad share vid/pid — so DWT
was silently inoperative under keyd.

**Change.** A GZ302-gated `/etc/xkb` override replaces keyd:

- `roles/hardware/files/xkb/rules/evdev` includes the system `%S/evdev` rules
  and appends `+gz302(copilot)` to every model's symbols.
- `roles/hardware/files/xkb/symbols/gz302` types `<FK23>` as
  `ONE_LEVEL [ F23 ]`.
- `roles/hardware/tasks/gz302.yml` creates `/etc/xkb/{rules,symbols}` and
  copies both files; the "Install GZ302 packages", "Deploy keyd config", and
  "Enable and start keyd" tasks are gone.
- `roles/hardware/vars/main.yml` drops `hardware_gz302_pacman`,
  `roles/hardware/handlers/main.yml` is deleted (the "Restart keyd" handler was its last entry once #347 removed the network handler), and
  `roles/hardware/templates/keyd-default.conf.j2` is deleted.
- `roles/kde/tasks/main.yml` changes the launcher binding from `F23` to
  `Meta+Shift+F23`.

`/etc/xkb` is a built-in libxkbcommon include path that KWin already
searches. KWin subtracts only *consumed* modifiers
(`Xkb::modifiersRelevantForGlobalShortcuts`, kwin 6.7.4 `src/xkb.cpp`) and a
`ONE_LEVEL` key consumes none, so the chord reaches kglobalaccel as
`Meta+Shift+F23` — hence the kde binding change.

**Breaking change** (commit 1 is marked `!`): keyd is no longer managed. On
hosts provisioned before this change it stays installed and enabled, and with
keyd running its grab still strips the modifiers so the new binding does not
match. Remove it by hand:

```
sudo systemctl disable --now keyd && sudo pacman -Rns keyd
```

### Testing:

```
pre-commit run --all-files        # all hooks Passed
XKB_CONFIG_EXTRA_PATH=roles/hardware/files/xkb xkbcli compile-keymap --layout us --model pc105 | grep -A2 'key <FK23>'   # ONE_LEVEL, [ F23 ]
CI: lint + check (container --check provisioning) green
```

Actual outputs recorded on this branch:

- `pre-commit run --all-files`: every hook Passed; `check for broken symlinks`,
  `check toml`, and `forbid new submodules` Skipped (no matching files).
- `XKB_CONFIG_EXTRA_PATH=roles/hardware/files/xkb xkbcli compile-keymap --layout us --model pc105 | grep -A2 'key <FK23>'`:

  ```
  key <FK23>               {
          type= "ONE_LEVEL",
          symbols[1]= [             F23 ]
  ```

  This compiles the repository's override against the system
  xkeyboard-config through the same include mechanism KWin uses — `/etc/xkb`
  is the default value of `XKB_CONFIG_EXTRA_PATH`.
- `grep -rn 'keyd\|hardware_gz302_pacman' roles playbook.yml`: no matches.

Verified live on a GZ302EAC on 2026-08-27 (Plasma 6.7.4, xkeyboard-config
2.48, libxkbcommon 1.13.2): override installed, keyd stopped, new session,
`xkbcli dump-keymap-wayland` shows `<FK23>` as `ONE_LEVEL [F23]`, and the
Copilot key launches Claude Code through the `Meta+Shift+F23` alternative.

### Extra Notes (optional):

- After the first deploy, log out and back in: libxkbcommon adds `/etc/xkb`
  to the include path only if the directory exists when KWin creates its xkb
  context, and KWin reads that path once at startup.
- kglobalaccel reads the `[services][...]` group at session start, so the
  binding change also takes effect at the next login (see
  `.claude/skills/kde-config/lessons/shortcuts.md`).

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — not run locally (the Docker daemon is not running in this environment); the `check` CI job runs the same `--check` provisioning build.


