### PR TITLE
fix(ai): drop ggml-cpu, absorbed into ggml 0.22.0

### DIFF
--- a/roles/ai/defaults/main.yml
+++ b/roles/ai/defaults/main.yml
@@ -1,9 +1,10 @@
 ---
 # llama.cpp from the CachyOS-provided repos (Arch `extra`, mirrored by
 # CachyOS). Upstream splits the runtime into the frontend binaries
-# (llama-cpp) and one package per ggml backend, loaded dynamically at
-# runtime — so the backend set is chosen here, by which ggml-* packages
-# get installed.
+# (llama-cpp), the core library with the CPU backend built in (ggml, a
+# hard dependency of llama-cpp) and one package per GPU backend, loaded
+# dynamically at runtime — so the GPU backend set is chosen here, by
+# which ggml-* packages get installed.
 ai_pacman:
   # CLI tooling and the HTTP server: /usr/bin/llama-cli,
   # /usr/bin/llama-server, plus llama-bench/llama-quantize et al.
@@ -13,8 +14,7 @@ ai_pacman:
   # an optional dep by `ggml`, so it is not implied by llama-cpp and has
   # to be requested explicitly.
   - ggml-hip
-  # CPU backend, also an optional dep of `ggml`. Required for everything
-  # that stays on the host — tokenization and any layer not offloaded —
-  # so llama.cpp stays usable when a model exceeds VRAM or the GPU
-  # backend is unavailable.
-  - ggml-cpu
+  # No ggml-cpu: since ggml 0.22.0 the CPU backend ships inside `ggml`,
+  # which provides and conflicts with the retired package. Listing a
+  # name that is only provided fails every rerun — `pacman -Q` never
+  # lists it, so the module retries it and hits the conflict.

--- a/roles/ai/defaults/main.yml
+++ b/roles/ai/defaults/main.yml
@@ -14,7 +14,3 @@ ai_pacman:
   # an optional dep by `ggml`, so it is not implied by llama-cpp and has
   # to be requested explicitly.
   - ggml-hip
-  # No ggml-cpu: since ggml 0.22.0 the CPU backend ships inside `ggml`,
-  # which provides and conflicts with the retired package. Listing a
-  # name that is only provided fails every rerun — `pacman -Q` never
-  # lists it, so the module retries it and hits the conflict.


### PR DESCRIPTION
## Problem

Rerunning `hanzo` on an already provisioned machine fails at `ai : Install AI pacman packages`:

```
unresolvable package conflicts detected
:: ggml-cpu-0.21.0-1 and ggml-0.22.0-1 are in conflict. Remove ggml? [y/N]
```

## Cause

Arch `extra` published `ggml 0.22.0-1` on 2026-08-26 with the CPU backend built in: it `provides` and `conflicts` `ggml-cpu`, and no `ggml-cpu` 0.22 was built, leaving the orphaned `ggml-cpu 0.21.0-1` in the database ([archlinux.org](https://archlinux.org/packages/extra/x86_64/ggml-cpu/), flagged out-of-date).

- **First run passes**: `ggml` is pulled as a dependency, provides `ggml-cpu`, and pacman silently drops `ggml-cpu` from the target list (`warning: removing 'ggml-cpu' from target list because it conflicts with 'ggml'`). Exit 0, task green. This is also why the weekly `--ci` build stays green: a fresh container is always a first run.
- **Every rerun fails**: `community.general.pacman` decides what to install by name against `pacman -Q`, which never lists *provided* packages, so it retries `ggml-cpu`, resolves the stale 0.21 package, and hits a conflict with the installed `ggml` that `--noconfirm` cannot accept.

## Fix

Remove `ggml-cpu` from `ai_pacman`; the CPU backend is part of `ggml`, a hard dependency of `llama-cpp`. Already provisioned machines need nothing: they have `ggml 0.22.0`, which contains `libggml-cpu`.

## Verification

- `pre-commit run --all-files`: pass
- `docker build --build-arg HANZO_ARGS=--check -f tests/Containerfile -t hanzo:test .`: pass (`failed=0`)