### PR TITLE
fix(kde): stop failing on the virtual keyboard availability check

### DIFF
--- a/.claude/skills/kde-config/lessons/input-devices.md
+++ b/.claude/skills/kde-config/lessons/input-devices.md
@@ -32,16 +32,30 @@ its `.desktop` file to be a valid candidate (`find /usr/share/applications
 
 Live-verify via `busctl --user get-property org.kde.KWin /VirtualKeyboard
 org.kde.kwin.VirtualKeyboard available` (should read `true`) - the process
-itself shows up as `plasma-keyboard` in `pgrep`.
+itself shows up as `plasma-keyboard` in `pgrep`. `available` only means KWin
+holds a non-empty `Exec` command (`InputMethod::isAvailable()`), not that
+the process is running.
 
-### Gotcha: equality guard breaks naive idempotency
+### Gotcha: an unchanged write sends no notification
 
-`setInputMethodCommand()` no-ops if the new value equals the *current
-in-memory* value - even if that value has drifted from what's actually on
-disk. Observed live: `available` stayed `false` and the process wasn't
-running despite the correct key already being in `kwinrc`.
+KWin only learns of the key through a `KConfigWatcher` on the
+`org.kde.kconfig.notify.ConfigChanged` D-Bus signal, and KConfig only emits
+it for entries whose value actually changed (`KEntry::operator==` ignores
+the dirty/notify flags on purpose). Observed live: the correct key already
+in `kwinrc`, `available` `false`, and a plain write of the same value
+changed nothing.
 
-Fix: always write an empty value first (forcing a real transition), then
-the target value, each with `kwriteconfig6 --notify`. This is what makes
-`virtual-keyboard.sh` reliably idempotent even after selecting "None" in the
-GUI, which removes the key entirely.
+Fix: always write an empty value first, then the target, each with
+`kwriteconfig6 --notify` - the transition is what makes KConfig notify.
+This also covers "None" in the GUI, which removes the key entirely.
+
+### Gotcha: `kwriteconfig6 --notify` can lose the signal
+
+`kwriteconfig6` hands the D-Bus signal to Qt's D-Bus worker thread and
+exits without flushing, so on a busy system (mid-install) the process can
+quit before the signal is written and KWin is never told. `kwinrc` is
+still correct and KWin reads it at the next session start. This is why
+`virtual-keyboard.sh` does not verify `available` after applying: the
+task-level `available` guard re-applies on the next run instead of the play
+failing on a lost notification. The System Settings KCM never hits this -
+it is a long-lived process.

--- a/roles/kde/files/virtual-keyboard.sh
+++ b/roles/kde/files/virtual-keyboard.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 
 # Sets the Wayland virtual keyboard (on-screen keyboard input method) to
-# the given .desktop file and verifies KWin reports it available.
+# the given .desktop file.
 #
-# Always writes empty first, then the target, each with --notify: KWin's
-# setInputMethodCommand() no-ops when the new value equals the current
-# in-memory value even if the live state has drifted, so a real
-# transition must be forced (see lessons/input-devices.md). The caller
-# guards invocation, so this script applies unconditionally.
+# Writes empty first, then the target, each with --notify: KConfig sends
+# no change notification for a value already on disk (see
+# lessons/input-devices.md). The caller guards invocation, so this script
+# applies unconditionally.
 #
 # Config:
 #   VIRTUAL_KEYBOARD_DESKTOP_FILE=/usr/share/applications/org.kde.plasma.keyboard.desktop (default)
@@ -21,15 +20,6 @@ if [ ! -f "$VIRTUAL_KEYBOARD_DESKTOP_FILE" ]; then
 fi
 
 kwriteconfig6 --file kwinrc --group Wayland --key InputMethod "" --notify
-sleep 1
 kwriteconfig6 --file kwinrc --group Wayland --key InputMethod "$VIRTUAL_KEYBOARD_DESKTOP_FILE" --notify
-sleep 1
 
-available=$(busctl --user get-property org.kde.KWin /VirtualKeyboard org.kde.kwin.VirtualKeyboard available 2>/dev/null | awk '{print $2}')
-
-if [ "$available" != "true" ]; then
-  echo "Virtual keyboard did not report available=true after applying - check 'busctl --user get-property org.kde.KWin /VirtualKeyboard org.kde.kwin.VirtualKeyboard available'." >&2
-  exit 1
-fi
-
-echo "Virtual keyboard set to $VIRTUAL_KEYBOARD_DESKTOP_FILE (available=true)."
+echo "Virtual keyboard set to $VIRTUAL_KEYBOARD_DESKTOP_FILE."

--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -62,10 +62,10 @@
   become: false
 
 # --- Virtual keyboard -------------------------------------------------
-# The applier always writes empty-then-target to defeat KWin's in-memory
-# equality guard, so it cannot self-report change — guard it on the live
+# The applier always writes empty-then-target (KConfig only notifies on
+# a real change), so it cannot self-report change — guard it on the live
 # state instead. `available` covers the case where the key is already
-# correct on disk but the input method is not actually running.
+# correct on disk but KWin never picked it up.
 
 - name: Read configured virtual keyboard
   ansible.builtin.command:


### PR DESCRIPTION
### Related Issues

N/A — no tracking issue. Hit during a one-shot install.

### Proposed Changes:

**Problem.** `virtual-keyboard.sh` wrote `kwinrc [Wayland] InputMethod` and, one second later, failed the play unless `busctl … /VirtualKeyboard available` read `true`. During a one-shot install it read `false` although the key was correct on disk and System Settings showed Plasma Keyboard selected; toggling None → Plasma Keyboard in the KCM made it `true`.

`available` is `!m_inputMethodCommand.isEmpty()` in KWin — it only says KWin holds a non-empty `Exec`, nothing about the process. KWin learns of the key solely through a `KConfigWatcher` on the `org.kde.kconfig.notify.ConfigChanged` D-Bus signal. `kwriteconfig6 --notify` hands that signal to Qt's D-Bus worker thread (queued cross-thread connection) and exits without flushing; on a busy system (pacman just finished, KWin starting `plasma-keyboard`) the process quits before the signal is written and KWin is never told. The KCM never hits this — it's a long-lived process, so its notification always goes out.

**Change.**

- `roles/kde/files/virtual-keyboard.sh`: drop the post-apply `available` check and both sleeps. The key is correct on disk and KWin reads it at the next session start; the task-level `available` guard in `roles/kde/tasks/main.yml` re-applies on the next run, so a lost notification heals instead of failing the play.
- Keep the empty-then-target double write, with its real reason: `KEntry::operator==` deliberately ignores the dirty/notify flags, so writing a value already on disk emits no notification — a drifted KWin would never be told by a single write. The previous "KWin equality guard" explanation was wrong: that guard compares against the in-memory command, which is empty whenever `available` is `false`.
- `.claude/skills/kde-config/lessons/input-devices.md`: rewrite the gotcha accordingly and record the lost-signal behaviour; note that `available` does not mean the process is running.

Sources: [KWin `inputmethod.cpp`](https://invent.kde.org/plasma/kwin/-/blob/master/src/inputmethod.cpp), [KWin `main_wayland.cpp` `refreshSettings()`](https://invent.kde.org/plasma/kwin/-/blob/master/src/main_wayland.cpp), [`kwriteconfig.cpp`](https://invent.kde.org/frameworks/kconfig/-/blob/master/src/kreadconfig/kwriteconfig.cpp), [`kconfigdata_p.h` `KEntry::operator==`](https://invent.kde.org/frameworks/kconfig/-/blob/master/src/core/kconfigdata_p.h), [Qt `qdbusintegrator.cpp`](https://github.com/qt/qtbase/blob/6.9/src/dbus/qdbusintegrator.cpp).

### Testing:

- `pre-commit run --all-files` — passes.
- `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .` — passes (the container has no Plasma, so the kde role is skipped; this proves syntax and lint).
- Real verification is on the machine: run `hanzo` and confirm the play no longer stops at "Set virtual keyboard to Plasma Keyboard"; a second run should report the task unchanged when `available` reads `true`.

### Extra Notes (optional):

This is the "don't block" option. The `kwriteconfig6` race itself is untouched; closing it would mean emitting the KConfigWatcher signal from a tool that flushes (`busctl emit`) — a separate change if wanted.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`
