### PR TITLE
fix(hardware): keep cores out of C2/C3 while hibernating on the GZ302

### DIFF
--- a/roles/hardware/files/hibernate-cstate
+++ b/roles/hardware/files/hibernate-cstate
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Managed by Hanzo. Do not edit manually.
+#
+# Keep online cores out of C2/C3 while hibernating. On this platform a core
+# leaving the deepest C-state during the hibernate CPU offline/online sequence
+# loses its XSAVE control state and the hibernation hangs.
+# See https://github.com/palazzem/hanzo/issues/354
+[ "$SYSTEMD_SLEEP_ACTION" = "hibernate" ] || exit 0
+
+set_deep_cstates() {
+  for f in /sys/devices/system/cpu/cpu*/cpuidle/state[23]/disable; do
+    echo "$1" > "$f"
+  done
+}
+
+case "$1" in
+  pre)  set_deep_cstates 1 ;;
+  post) set_deep_cstates 0 ;;
+esac

--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -17,6 +17,13 @@
     - host_has_systemd
   become: true
 
+- name: Deploy hibernate C-state workaround hook
+  ansible.builtin.copy:
+    src: hibernate-cstate
+    dest: /usr/lib/systemd/system-sleep/hibernate-cstate
+    mode: "0755"
+  become: true
+
 - name: Create XKB override directories
   ansible.builtin.file:
     path: "/etc/xkb/{{ item }}"


### PR DESCRIPTION
### Related Issues

Workaround for #354. This is not a fix for the underlying defect, so that issue stays open.

### Proposed Changes:

The ASUS ROG Flow Z13 GZ302EAC (Strix Halo) has a firmware/CPU power-state defect: a core leaving the deepest C-state during the hibernate CPU offline/online sequence comes back without its XSAVE control state, which hangs hibernation on battery with the low-power profile.

This deploys a systemd `system-sleep` hook at `/usr/lib/systemd/system-sleep/hibernate-cstate` (mode `0755`) that disables cpuidle states 2 and 3 on all online cores before the hibernate phase and re-enables them after resume:

- The hook exits immediately unless `SYSTEMD_SLEEP_ACTION` is `hibernate`.
- On `pre` it writes `1` to `/sys/devices/system/cpu/cpu*/cpuidle/state[23]/disable`; on `post` it writes `0`.
- Per `man systemd-sleep` (systemd 261), `SYSTEMD_SLEEP_ACTION` is `hibernate` during the hibernate phase of `suspend-then-hibernate` as well as a direct hibernate, so the hook covers both the lid-close path from the issue and plain hibernate. It deliberately does not run for plain suspend, and does not cover `hybrid-sleep` (not used by Hanzo's logind configuration).
- The hook is deployed by a new `ansible.builtin.copy` task in `roles/hardware/tasks/gz302.yml`, gated by the existing `model_is_gz302` fact like the rest of that file. The source lives at `roles/hardware/files/hibernate-cstate`.

The hook should be dropped once a BIOS or kernel-side fix for the underlying power-state defect lands.

### Testing:

- `pre-commit run --all-files` passes (shellcheck on the hook, ansible-lint, shebang/executable checks).
- The container provisioning check (`docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .`) was **not** run for this change, at the owner's request.

### Extra Notes (optional):

None.

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior — not applicable; this is a shell hook validated via shellcheck and manual behavior review against `man systemd-sleep`, not unit-testable Ansible logic.
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — not run for this change, at the owner's request.
