### PR TITLE
feat(kde): switch virtual desktops independently per screen

### DIFF
--- a/.claude/skills/kde-config/SKILL.md
+++ b/.claude/skills/kde-config/SKILL.md
@@ -217,7 +217,7 @@ not from memory.
 | Setting | Implementation | Lesson file(s) |
 |---|---|---|
 | Touchpad | `files/touchpad.sh` | `lessons/input-devices.md` |
-| Virtual desktops | `files/virtual-desktops.sh` | `lessons/layouts.md` |
+| Virtual desktops (count, rows, per-screen switching) | `files/virtual-desktops.sh`, `tasks/main.yml` (ini_file + handler) | `lessons/layouts.md` |
 | Global shortcuts (Meta+N desktops, Spectacle captures) | `files/bind-shortcuts.py` | `lessons/shortcuts.md` |
 | Display | `files/display.sh` | `lessons/display.md` |
 | Virtual keyboard | `files/virtual-keyboard.sh` | `lessons/input-devices.md` |

--- a/.claude/skills/kde-config/lessons/layouts.md
+++ b/.claude/skills/kde-config/lessons/layouts.md
@@ -11,6 +11,16 @@ read-only, use `createDesktop(position: uint, name: string)` to add one and
 the writable `rows` property for grid layout. No dedicated CLI tool exists
 for this - use the D-Bus interface directly.
 
+"Switch desktops independently for each screen" is **not** on that D-Bus
+interface (no property for it). It is the plain `kwinrc` key
+`[Windows] PerOutputVirtualDesktops=true|false` (kcfg:
+`kwin/src/kcms/desktop/virtualdesktopssettings.kcfg`). The generic
+`reconfigure` applies it live: `Options` re-reads the key on config load and
+`workspace.cpp` connects `Options::perOutputVirtualDesktopsChanged` to
+`VirtualDesktopManager::setPerOutputVirtualDesktops`. Same group as
+`RollOverDesktops` ("Navigation wraps around"), which the D-Bus interface
+*does* expose as `navigationWrappingAround`.
+
 ## Plasma Scripting API (`org.kde.PlasmaShell.evaluateScript`)
 
 The same mechanism used by Look-and-Feel package layouts and layout

--- a/roles/kde/defaults/main.yml
+++ b/roles/kde/defaults/main.yml
@@ -4,9 +4,11 @@ kde_touchpad_natural_scroll: "true"
 kde_touchpad_tap_to_click: "false"
 kde_touchpad_click_method: clickfinger
 
-# Virtual desktops, and the Meta+N shortcuts bound to them.
+# Virtual desktops, and the Meta+N shortcuts bound to them. The boolean
+# is quoted: KConfig reads lowercase true|false.
 kde_virtual_desktops: 5
 kde_virtual_desktop_rows: 1
+kde_virtual_desktops_per_screen: "true"
 
 # Global shortcuts, added as alternatives to each action's existing keys.
 kde_global_shortcuts:

--- a/roles/kde/tasks/main.yml
+++ b/roles/kde/tasks/main.yml
@@ -36,6 +36,17 @@
   changed_when: "'CHANGED' in kde_desktops_result.stdout"
   become: false
 
+- name: Set per-screen virtual desktop switching
+  community.general.ini_file:
+    path: "{{ ansible_facts.env.HOME }}/.config/kwinrc"
+    section: Windows
+    option: PerOutputVirtualDesktops
+    value: "{{ kde_virtual_desktops_per_screen }}"
+    no_extra_spaces: true
+    mode: "0644"
+  become: false
+  notify: Reconfigure KWin
+
 - name: Build Meta+N virtual desktop shortcut bindings
   ansible.builtin.set_fact:
     kde_desktop_shortcuts: >-


### PR DESCRIPTION
### Related Issues

- N/A

### Proposed Changes:

By default KDE keeps a single set of virtual desktops shared across all
monitors, so switching desktops on one screen switches every screen at
once. This adds the `roles/kde` setting for KDE System Settings' "Switch
desktops independently for each screen" checkbox (Window Management >
Virtual Desktops), so each screen keeps its own current desktop.

That checkbox maps to the `kwinrc` key `[Windows] PerOutputVirtualDesktops`,
confirmed from `src/kcms/desktop/virtualdesktopssettings.kcfg` in
plasma/kwin (also present in the installed
`/usr/share/config.kcfg/virtualdesktopssettings.kcfg`, kwin 6.7.4). It is
not exposed on the `org.kde.KWin.VirtualDesktopManager` D-Bus interface -
`busctl introspect` on that interface shows only `count`, `rows`,
`navigationWrappingAround`, `current`, and `desktops` - which is why this
setting is written with `community.general.ini_file` instead of being added
to `files/virtual-desktops.sh` alongside the other virtual desktop
settings.

Live application through the existing `Reconfigure KWin` handler is
grounded in kwin's source: `src/options.cpp` calls
`setPerOutputVirtualDesktops(m_settings->perOutputVirtualDesktops())` on
config load, and `src/workspace.cpp` (lines 218-219) connects
`Options::perOutputVirtualDesktopsChanged` to
`VirtualDesktopManager::setPerOutputVirtualDesktops`, so no session restart
is needed.

The behaviour is tunable through a new `kde_virtual_desktops_per_screen:
"true"` default in `roles/kde/defaults/main.yml`.

The `kde-config` skill's `lessons/layouts.md` and the `SKILL.md` settings
table were updated with these facts so future changes to this area don't
need to rediscover them.

### Testing:

- `pre-commit run --all-files`: all hooks passed, including ansible-lint.
- The container `--check` build was **not** run for this PR, at the
  author's request, because the Docker daemon was not running on the
  authoring host; CI runs it. Note that the `kde` role is skipped in the
  container regardless (no Plasma, `host_has_kde` is false), so the
  container build only proves syntax for this change, not behaviour.
- Live behaviour is unverified in this PR: the author will run `hanzo` on a
  Plasma machine, then run it a second time to confirm the task reports no
  change. The key is already `true` on the author's machine, so the first
  run is expected to report `ok` rather than `changed`.

### Extra Notes (optional):

None.

### Checklist

- [x] Related issue and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior - no dedicated
  test harness exists for role behaviour beyond the container `--check`
  build and manual Plasma verification described above.
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` - not run for this PR (Docker daemon unavailable on the authoring host); CI runs it, and the `kde` role is skipped in the container regardless.
