### PR TITLE
fix(hardware): enable Chrome VA-API decode on the GZ302

### DIFF
--- a/roles/hardware/tasks/gz302.yml
+++ b/roles/hardware/tasks/gz302.yml
@@ -47,3 +47,18 @@
     dest: /etc/xkb/symbols/gz302
     mode: "0644"
   become: true
+
+- name: Deploy Chrome flags enabling VA-API on Strix Halo
+  ansible.builtin.copy:
+    dest: "{{ ansible_facts.env.HOME }}/.config/chrome-flags.conf"
+    content: |
+      # Managed by Hanzo. Do not edit manually.
+      # Chromium driver-bug entry 475 disables VA-API on the Radeon 8060S
+      # (1002:1586) because of an amdgpu SMU deadlock fixed in kernel 7.1.
+      # Skipping the workaround list restores hardware video decode.
+      # Requires kernel >= 7.1; drop once Chromium removes the entry.
+      # https://github.com/palazzem/hanzo/issues/357
+      --disable-gpu-driver-bug-workarounds
+      --enable-features=AcceleratedVideoEncoder
+    mode: "0644"
+  become: false


### PR DESCRIPTION
### Related Issues

- Closes #357

### Proposed Changes:

Chromium ships a driver-bug workaround (entry 475) that disables VA-API for the Radeon 8060S (PCI ID 1002:1586) found in the GZ302's Strix Halo APU, because of an amdgpu SMU deadlock. That deadlock was fixed in kernel 7.1, and CachyOS currently ships kernel 7.2.2, so the workaround is no longer needed on this hardware but Chromium still applies it, leaving hardware video decode disabled in Chrome/Chromium.

The `gz302` hardware role now deploys `~/.config/chrome-flags.conf` with:

- `--disable-gpu-driver-bug-workarounds`, which skips the driver-bug list so the GPU process loads the VA-API driver again for hardware decode.
- `--enable-features=AcceleratedVideoEncoder`, which enables VA-API encode for WebRTC. This second flag has not yet been verified on the affected hardware.

The task is gated by `model_is_gz302` through the existing include in `roles/hardware/tasks/main.yml`, so it only applies on this hardware.

**Safety note:** this override must not be used on kernels older than 7.1 on this hardware, since it re-enables the exact workload that triggers the amdgpu SMU deadlock and hard-hangs the machine. The file should be removed once Chromium drops driver-bug entry 475.

### Testing:

- `pre-commit run --all-files` passes.
- The container check (`docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .`) could not be run locally because the Docker daemon was inactive on the host; CI runs this check on the PR.

### Extra Notes (optional):

None.

### Checklist

- [x] Related issue and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior — not applicable, this task deploys a static config file gated by an existing hardware detection fact
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [ ] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .` — could not run locally (Docker daemon inactive on host); CI will run it on this PR
