### PR TITLE
feat(tools): add postgresql-libs for the psql client

### DIFF
--- a/roles/tools/defaults/main.yml
+++ b/roles/tools/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 tools_dev_pacman:
   - github-cli
+  - postgresql-libs
 
 tools_uv_tools:
   - ipython


### PR DESCRIPTION
### Related Issues

- none

### Proposed Changes:

Adds `postgresql-libs` to `tools_dev_pacman` in the `tools` role. The package ships the `psql` client and `libpq` without pulling in the PostgreSQL server, so a workstation can connect to remote databases with no local daemon.

Verified against `cachyos/cachyos:latest` that no PostgreSQL package is present in the base image.

### Testing:

- `pre-commit run --all-files` passes
- `docker build --build-arg HANZO_ARGS="--check" -f tests/Containerfile -t hanzo:test .` passes

### Checklist

- [x] Related issue and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Commits follow [Conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Lint passes: `pre-commit run --all-files`
- [x] Container test passes: `docker build -f tests/Containerfile -t hanzo:test .`
